### PR TITLE
feat: tab completion for tilde expansions

### DIFF
--- a/src/completion.zig
+++ b/src/completion.zig
@@ -11,6 +11,7 @@ const runner = @import("runner.zig");
 const runtime = @import("runtime.zig");
 const shell_state_mod = @import("shell/state.zig");
 const editor_completion = @import("editor/completion.zig");
+const expand = @import("shell/expand.zig");
 
 pub const CancellationToken = editor_completion.CancellationToken;
 pub const Kind = editor_completion.Kind;
@@ -1658,6 +1659,7 @@ fn appendProviderCandidates(
                 semantic.replace_start,
                 semantic.replace_end,
                 .{},
+                shell_state.envLookup(),
             );
             defer freeCandidates(allocator, candidates);
             for (candidates) |candidate| try builder.appendCandidateIfMissing(allocator, candidate);
@@ -1670,6 +1672,7 @@ fn appendProviderCandidates(
                 semantic.replace_start,
                 semantic.replace_end,
                 .{ .directories_only = true },
+                shell_state.envLookup(),
             );
             defer freeCandidates(allocator, candidates);
             for (candidates) |candidate| try builder.appendCandidateIfMissing(allocator, candidate);
@@ -1735,6 +1738,7 @@ fn appendFunctionProviderCandidates(
         value_position,
         parsed_options,
         operands,
+        shell_state.envLookup(),
     );
     defer provider_state.deinit();
 
@@ -2241,7 +2245,7 @@ pub fn defaultPathApplication(
     const word = try decodeShellCompletionSlice(allocator, source, replace_start, replace_end);
     defer allocator.free(word);
 
-    const candidates = try pathCandidates(allocator, io, word, replace_start, replace_end);
+    const candidates = try pathCandidates(allocator, io, word, replace_start, replace_end, .{});
     defer freeCandidates(allocator, candidates);
     return applyCandidatesForInputWithPolicy(allocator, source, candidates, .prefixOnly());
 }
@@ -2270,7 +2274,7 @@ pub fn defaultApplication(
     const candidates = if (context.kind == .command and std.mem.indexOfScalar(u8, word, '/') == null)
         try commandCandidates(allocator, io, shell_state, replace_start, replace_end)
     else
-        try pathCandidates(allocator, io, word, replace_start, replace_end);
+        try pathCandidates(allocator, io, word, replace_start, replace_end, shell_state.envLookup());
     defer freeCandidates(allocator, candidates);
     return applyCandidatesForInputWithPolicy(allocator, source, candidates, .prefixOnly());
 }
@@ -2296,8 +2300,9 @@ fn pathCandidates(
     word: []const u8,
     replace_start: usize,
     replace_end: usize,
+    env: expand.EnvLookup,
 ) ![]Candidate {
-    return pathCandidatesWithOptions(allocator, io, word, replace_start, replace_end, .{});
+    return pathCandidatesWithOptions(allocator, io, word, replace_start, replace_end, .{}, env);
 }
 
 const PathCandidateOptions = struct {
@@ -2311,12 +2316,14 @@ fn pathCandidatesWithOptions(
     replace_start: usize,
     replace_end: usize,
     options: PathCandidateOptions,
+    env: expand.EnvLookup,
 ) ![]Candidate {
     const split = std.mem.findScalarLast(u8, word, '/');
     const dir_prefix = if (split) |index| word[0 .. index + 1] else "";
     const entry_prefix = if (split) |index| word[index + 1 ..] else word;
-    const dir_path = pathDirectoryToOpen(dir_prefix);
-
+    const dir_path_raw = if (dir_prefix.len == 0) "." else dir_prefix;
+    const dir_path = try expand.expandTilde(allocator, dir_path_raw, env);
+    defer allocator.free(dir_path);
     var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound, error.NotDir, error.AccessDenied => return &.{},
         else => return err,
@@ -2644,8 +2651,8 @@ fn appendShellEscapedValue(
 }
 
 fn needsUnquotedEscape(byte: u8, index: usize) bool {
+    _ = index;
     if (std.ascii.isWhitespace(byte)) return true;
-    if (index == 0 and byte == '~') return true;
     return switch (byte) {
         '\\', '\'', '"', '`', '$', '&', '|', ';', '<', '>', '(', ')', '[', ']', '{', '}', '*', '?', '!', '#' => true,
         else => false,
@@ -4009,7 +4016,7 @@ test "application decodes escaped prefixes before matching and reinserts escaped
     try std.testing.expectEqualStrings("two\\ words", edit.replacement);
 }
 
-test "application escapes tilde and keeps directory completions open" {
+test "application preserves tilde and keeps directory completions open" {
     const tilde_source = "cat ~li";
     const tilde_candidates = [_]Candidate{.{
         .value = "~literal?",
@@ -4018,7 +4025,7 @@ test "application escapes tilde and keeps directory completions open" {
     }};
     const tilde_application = try applyCandidatesForInput(std.testing.allocator, tilde_source, &tilde_candidates);
     defer tilde_application.deinit(std.testing.allocator);
-    try std.testing.expectEqualStrings("\\~literal\\?", tilde_application.edit.replacement);
+    try std.testing.expectEqualStrings("~literal\\?", tilde_application.edit.replacement);
 
     const dir_source = "cat dir";
     const dir_candidates = [_]Candidate{.{

--- a/src/completion.zig
+++ b/src/completion.zig
@@ -584,6 +584,7 @@ pub const SemanticContext = struct {
     root: []const u8 = "",
     path: []const []const u8 = &.{},
     prefix: []const u8 = "",
+    expand_tilde: bool = false,
     argument_index: usize = 0,
     argument_state: ?[]const u8 = null,
     parsed_options: []const ParsedOption = &.{},
@@ -1089,6 +1090,7 @@ pub const State = struct {
             .operands = owned_operands,
             .options_terminated = semantic.options_terminated,
             .prefix = semantic.prefix,
+            .expand_tilde = semantic.expand_tilde,
             .argument_index = semantic.argument_index,
             .argument_state = semantic.argument_state,
             .previous = semantic.previous,
@@ -1414,6 +1416,7 @@ fn semanticContextForCommand(
         .root = command.argv[0].text,
         .path = owned_path,
         .prefix = prefix,
+        .expand_tilde = shellCompletionContext(source, replace_start).quote == .unquoted,
         .argument_index = operand_index,
         .parsed_options = owned_parsed_options,
         .operands = owned_operands,
@@ -1658,7 +1661,7 @@ fn appendProviderCandidates(
                 semantic.prefix,
                 semantic.replace_start,
                 semantic.replace_end,
-                .{},
+                .{ .expand_tilde = semantic.expand_tilde },
                 shell_state.envLookup(),
             );
             defer freeCandidates(allocator, candidates);
@@ -1671,7 +1674,7 @@ fn appendProviderCandidates(
                 semantic.prefix,
                 semantic.replace_start,
                 semantic.replace_end,
-                .{ .directories_only = true },
+                .{ .directories_only = true, .expand_tilde = semantic.expand_tilde },
                 shell_state.envLookup(),
             );
             defer freeCandidates(allocator, candidates);
@@ -1739,6 +1742,7 @@ fn appendFunctionProviderCandidates(
         parsed_options,
         operands,
         shell_state.envLookup(),
+        semantic.expand_tilde,
     );
     defer provider_state.deinit();
 
@@ -2271,10 +2275,21 @@ pub fn defaultApplication(
     const word = try decodeShellCompletionSlice(allocator, source, replace_start, replace_end);
     defer allocator.free(word);
 
+    const path_options: PathCandidateOptions = .{
+        .expand_tilde = shellCompletionContext(source, replace_start).quote == .unquoted,
+    };
     const candidates = if (context.kind == .command and std.mem.indexOfScalar(u8, word, '/') == null)
         try commandCandidates(allocator, io, shell_state, replace_start, replace_end)
     else
-        try pathCandidates(allocator, io, word, replace_start, replace_end, shell_state.envLookup());
+        try pathCandidatesWithOptions(
+            allocator,
+            io,
+            word,
+            replace_start,
+            replace_end,
+            path_options,
+            shell_state.envLookup(),
+        );
     defer freeCandidates(allocator, candidates);
     return applyCandidatesForInputWithPolicy(allocator, source, candidates, .prefixOnly());
 }
@@ -2307,6 +2322,7 @@ fn pathCandidates(
 
 const PathCandidateOptions = struct {
     directories_only: bool = false,
+    expand_tilde: bool = false,
 };
 
 fn pathCandidatesWithOptions(
@@ -2321,8 +2337,11 @@ fn pathCandidatesWithOptions(
     const split = std.mem.findScalarLast(u8, word, '/');
     const dir_prefix = if (split) |index| word[0 .. index + 1] else "";
     const entry_prefix = if (split) |index| word[index + 1 ..] else word;
-    const dir_path_raw = if (dir_prefix.len == 0) "." else dir_prefix;
-    const dir_path = try expand.expandTilde(allocator, dir_path_raw, env);
+    const dir_path_raw = pathDirectoryToOpen(dir_prefix);
+    const dir_path = if (options.expand_tilde)
+        try expand.expandTilde(allocator, dir_path_raw, env)
+    else
+        try allocator.dupe(u8, dir_path_raw);
     defer allocator.free(dir_path);
     var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound, error.NotDir, error.AccessDenied => return &.{},
@@ -2480,6 +2499,7 @@ fn candidateReplacementAndSuffixForInput(
     source: []const u8,
     candidate: Candidate,
 ) !CandidateReplacement {
+    const preserve_initial_tilde = try shouldPreserveInitialTilde(allocator, source, candidate);
     return encodeShellCompletionReplacement(
         allocator,
         source,
@@ -2488,7 +2508,21 @@ fn candidateReplacementAndSuffixForInput(
         candidate.value,
         candidate.suffix,
         candidate.append_space,
+        preserve_initial_tilde,
     );
+}
+
+fn shouldPreserveInitialTilde(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    candidate: Candidate,
+) !bool {
+    if (candidate.value.len == 0 or candidate.value[0] != '~') return false;
+    const context = shellCompletionContext(source, candidate.replace_start);
+    if (context.quote != .unquoted or context.opening_quote != null) return false;
+    const prefix = try decodeShellCompletionSlice(allocator, source, candidate.replace_start, candidate.replace_end);
+    defer allocator.free(prefix);
+    return prefix.len != 0 and prefix[0] == '~' and std.mem.indexOfScalar(u8, prefix, '/') != null;
 }
 
 const ShellQuote = enum {
@@ -2589,14 +2623,15 @@ fn encodeShellCompletionReplacement(
     value: []const u8,
     suffix: ?[]const u8,
     append_space: bool,
+    preserve_initial_tilde: bool,
 ) !CandidateReplacement {
     const context = shellCompletionContext(source, replace_start);
     var encoded: std.ArrayList(u8) = .empty;
     errdefer encoded.deinit(allocator);
     if (context.opening_quote) |quote| try encoded.append(allocator, quote);
-    try appendShellEscapedValue(allocator, &encoded, context.quote, value);
+    try appendShellEscapedValue(allocator, &encoded, context.quote, value, preserve_initial_tilde);
     const suffix_start = encoded.items.len;
-    if (suffix) |text| try appendShellEscapedValue(allocator, &encoded, context.quote, text);
+    if (suffix) |text| try appendShellEscapedValue(allocator, &encoded, context.quote, text, false);
     const suffix_end = encoded.items.len;
     if (append_space and shouldCloseQuoteForCompletion(
         source,
@@ -2624,11 +2659,12 @@ fn appendShellEscapedValue(
     out: *std.ArrayList(u8),
     quote: ShellQuote,
     value: []const u8,
+    preserve_initial_tilde: bool,
 ) !void {
     switch (quote) {
         .unquoted => {
             for (value, 0..) |byte, index| {
-                if (needsUnquotedEscape(byte, index)) try out.append(allocator, '\\');
+                if (needsUnquotedEscape(byte, index, preserve_initial_tilde)) try out.append(allocator, '\\');
                 try out.append(allocator, byte);
             }
         },
@@ -2650,9 +2686,9 @@ fn appendShellEscapedValue(
     }
 }
 
-fn needsUnquotedEscape(byte: u8, index: usize) bool {
-    _ = index;
+fn needsUnquotedEscape(byte: u8, index: usize, preserve_initial_tilde: bool) bool {
     if (std.ascii.isWhitespace(byte)) return true;
+    if (index == 0 and byte == '~' and !preserve_initial_tilde) return true;
     return switch (byte) {
         '\\', '\'', '"', '`', '$', '&', '|', ';', '<', '>', '(', ')', '[', ']', '{', '}', '*', '?', '!', '#' => true,
         else => false,
@@ -2968,6 +3004,70 @@ test "default completion keeps argument position path-only" {
     const expected_replacement = try std.fmt.allocPrint(std.testing.allocator, "{s}/rush-file", .{tmp_root});
     defer std.testing.allocator.free(expected_replacement);
     try std.testing.expectEqualStrings(expected_replacement, edit.replacement);
+}
+
+test "default completion expands tilde only where the shell would" {
+    var shell_state = shell_state_mod.ShellState.init(std.testing.allocator);
+    defer shell_state.deinit();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(std.testing.io, "Downloads", .default_dir);
+
+    var tmp_root_buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const tmp_root_len = try tmp.dir.realPath(std.testing.io, &tmp_root_buffer);
+    const tmp_root = tmp_root_buffer[0..tmp_root_len];
+    try shell_state.putVariable("HOME", tmp_root, .{ .exported = true });
+
+    const unquoted_source = "cat ~/Down";
+    const unquoted_application = try defaultApplication(
+        std.testing.allocator,
+        std.testing.io,
+        shell_state,
+        unquoted_source,
+        unquoted_source.len,
+    );
+    defer unquoted_application.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("~/Downloads/", unquoted_application.edit.replacement);
+
+    const original_cwd = try std.process.currentPathAlloc(std.testing.io, std.testing.allocator);
+    defer std.testing.allocator.free(original_cwd);
+    try std.process.setCurrentPath(std.testing.io, tmp_root);
+    defer std.process.setCurrentPath(std.testing.io, original_cwd) catch unreachable;
+
+    const quoted_source = "cat \"~/Down";
+    const quoted_application = try defaultApplication(
+        std.testing.allocator,
+        std.testing.io,
+        shell_state,
+        quoted_source,
+        quoted_source.len,
+    );
+    defer quoted_application.deinit(std.testing.allocator);
+    try std.testing.expectEqual(Application.none, quoted_application);
+}
+
+test "default completion escapes literal leading tilde path names" {
+    var shell_state = shell_state_mod.ShellState.init(std.testing.allocator);
+    defer shell_state.deinit();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "~bob", .data = "" });
+
+    var tmp_root_buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const tmp_root_len = try tmp.dir.realPath(std.testing.io, &tmp_root_buffer);
+    const tmp_root = tmp_root_buffer[0..tmp_root_len];
+    const original_cwd = try std.process.currentPathAlloc(std.testing.io, std.testing.allocator);
+    defer std.testing.allocator.free(original_cwd);
+    try std.process.setCurrentPath(std.testing.io, tmp_root);
+    defer std.process.setCurrentPath(std.testing.io, original_cwd) catch unreachable;
+
+    const source = "cat ~b";
+    const application = try defaultApplication(std.testing.allocator, std.testing.io, shell_state, source, source.len);
+    defer application.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("\\~bob", application.edit.replacement);
 }
 
 test "manifest completion loads git subcommands lazily" {
@@ -4016,7 +4116,7 @@ test "application decodes escaped prefixes before matching and reinserts escaped
     try std.testing.expectEqualStrings("two\\ words", edit.replacement);
 }
 
-test "application preserves tilde and keeps directory completions open" {
+test "application escapes literal tilde and keeps directory completions open" {
     const tilde_source = "cat ~li";
     const tilde_candidates = [_]Candidate{.{
         .value = "~literal?",
@@ -4025,7 +4125,7 @@ test "application preserves tilde and keeps directory completions open" {
     }};
     const tilde_application = try applyCandidatesForInput(std.testing.allocator, tilde_source, &tilde_candidates);
     defer tilde_application.deinit(std.testing.allocator);
-    try std.testing.expectEqualStrings("~literal\\?", tilde_application.edit.replacement);
+    try std.testing.expectEqualStrings("\\~literal\\?", tilde_application.edit.replacement);
 
     const dir_source = "cat dir";
     const dir_candidates = [_]Candidate{.{

--- a/src/editor/driver.zig
+++ b/src/editor/driver.zig
@@ -32,7 +32,6 @@ const completion_progress_start = "\x1b]9;4;3\x07";
 const completion_progress_stop = "\x1b]9;4;0\x07";
 const completion_progress_delay_ms = 500;
 
-
 pub const TerminalEvent = terminal.Event;
 pub const ColorScheme = terminal.ColorScheme;
 pub const ColorReport = terminal.ColorReport;
@@ -143,7 +142,6 @@ pub const ReadLineResult = union(enum) {
 };
 
 const completion_flash_ms = 80;
-
 
 pub const TerminalSession = struct {
     allocator: std.mem.Allocator,

--- a/src/editor/vi.zig
+++ b/src/editor/vi.zig
@@ -678,4 +678,3 @@ pub fn isAsciiWhitespace(byte: u8) bool {
         else => false,
     };
 }
-

--- a/src/extensions/editor/rush_complete.zig
+++ b/src/extensions/editor/rush_complete.zig
@@ -38,6 +38,7 @@ pub const State = struct {
     candidates: std.ArrayList(editor_completion.Candidate) = .empty,
     next_source_order: usize = 0,
     env_lookup: expand.EnvLookup,
+    expand_tilde: bool,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -51,6 +52,7 @@ pub const State = struct {
         parsed_options: []const ParsedOption,
         operands: []const ParsedOperand,
         env_lookup: expand.EnvLookup,
+        expand_tilde: bool,
     ) State {
         return .{
             .allocator = allocator,
@@ -64,6 +66,7 @@ pub const State = struct {
             .parsed_options = parsed_options,
             .operands = operands,
             .env_lookup = env_lookup,
+            .expand_tilde = expand_tilde,
         };
     }
 
@@ -322,7 +325,10 @@ fn appendPathCandidates(state: *State, directories_only: bool) !void {
     const dir_prefix = if (split_after_separator) state.prefix[0 .. separator_index + 1] else "";
     const entry_prefix = if (split_after_separator) state.prefix[separator_index + 1 ..] else state.prefix;
     const dir_path_raw = if (dir_prefix.len == 0) "." else dir_prefix;
-    const dir_path = try expand.expandTilde(state.allocator, dir_path_raw, state.env_lookup);
+    const dir_path = if (state.expand_tilde)
+        try expand.expandTilde(state.allocator, dir_path_raw, state.env_lookup)
+    else
+        try state.allocator.dupe(u8, dir_path_raw);
     defer state.allocator.free(dir_path);
     var dir = std.Io.Dir.cwd().openDir(state.io, dir_path, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound, error.NotDir, error.AccessDenied => return,

--- a/src/extensions/editor/rush_complete.zig
+++ b/src/extensions/editor/rush_complete.zig
@@ -6,6 +6,7 @@ const api = @import("../api.zig");
 const editor_completion = @import("../../editor/completion.zig");
 const shell_builtin = @import("../../shell/builtin.zig");
 const shell_state_mod = @import("../../shell/state.zig");
+const expand = @import("../../shell/expand.zig");
 
 pub const builtins = [_]shell_builtin.Builtin{
     shell_builtin.Builtin.initExtension("rush_complete", .extension_state),
@@ -36,6 +37,7 @@ pub const State = struct {
     operands: []const ParsedOperand,
     candidates: std.ArrayList(editor_completion.Candidate) = .empty,
     next_source_order: usize = 0,
+    env_lookup: expand.EnvLookup,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -48,6 +50,7 @@ pub const State = struct {
         value_position: []const u8,
         parsed_options: []const ParsedOption,
         operands: []const ParsedOperand,
+        env_lookup: expand.EnvLookup,
     ) State {
         return .{
             .allocator = allocator,
@@ -60,6 +63,7 @@ pub const State = struct {
             .value_position = value_position,
             .parsed_options = parsed_options,
             .operands = operands,
+            .env_lookup = env_lookup,
         };
     }
 
@@ -317,7 +321,9 @@ fn appendPathCandidates(state: *State, directories_only: bool) !void {
     const split_after_separator = separator_index != 0 or std.mem.startsWith(u8, state.prefix, "/");
     const dir_prefix = if (split_after_separator) state.prefix[0 .. separator_index + 1] else "";
     const entry_prefix = if (split_after_separator) state.prefix[separator_index + 1 ..] else state.prefix;
-    const dir_path = if (dir_prefix.len == 0) "." else dir_prefix;
+    const dir_path_raw = if (dir_prefix.len == 0) "." else dir_prefix;
+    const dir_path = try expand.expandTilde(state.allocator, dir_path_raw, state.env_lookup);
+    defer state.allocator.free(dir_path);
     var dir = std.Io.Dir.cwd().openDir(state.io, dir_path, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound, error.NotDir, error.AccessDenied => return,
         else => return err,

--- a/src/shell/eval.zig
+++ b/src/shell/eval.zig
@@ -328,22 +328,19 @@ fn semanticCommandExecutionFrame(
     };
     try fd_table.applyRedirectionPlan(allocator, redirections);
     const stdin: execution_frame.InputEndpoint = switch (fd_table.boundEndpoint(0) orelse
-        @as(execution_frame.FdEndpoint, .{ .input = parent_frame.spec.stdin }))
-    {
+        @as(execution_frame.FdEndpoint, .{ .input = parent_frame.spec.stdin })) {
         .input => |input| input,
         .closed => .closed,
         .output => parent_frame.spec.stdin,
     };
     const stdout: execution_frame.OutputEndpoint = switch (fd_table.boundEndpoint(1) orelse
-        @as(execution_frame.FdEndpoint, .{ .output = parent_frame.spec.stdout }))
-    {
+        @as(execution_frame.FdEndpoint, .{ .output = parent_frame.spec.stdout })) {
         .output => |output| output,
         .closed => .discard,
         .input => parent_frame.spec.stdout,
     };
     const stderr: execution_frame.OutputEndpoint = switch (fd_table.boundEndpoint(2) orelse
-        @as(execution_frame.FdEndpoint, .{ .output = parent_frame.spec.stderr }))
-    {
+        @as(execution_frame.FdEndpoint, .{ .output = parent_frame.spec.stderr })) {
         .output => |output| output,
         .closed => .discard,
         .input => parent_frame.spec.stderr,
@@ -488,8 +485,7 @@ fn captureSet(
             .command_substitution_stdout => .{ .channels = &.{ .pipeline_data, .command_substitution_stdout } },
         },
         .command_substitution_stdout => switch (second orelse
-            return .{ .channels = &.{.command_substitution_stdout} })
-        {
+            return .{ .channels = &.{.command_substitution_stdout} }) {
             .side_stdout => .{ .channels = &.{ .command_substitution_stdout, .side_stdout } },
             .side_stderr => .{ .channels = &.{ .command_substitution_stdout, .side_stderr } },
             .pipeline_data => .{ .channels = &.{ .command_substitution_stdout, .pipeline_data } },
@@ -5172,24 +5168,24 @@ fn evaluateCommandSubstitutionBody(
         .simple => |plan| blk: {
             var input = EvaluationInput.empty();
             break :blk evaluatePlanWithInput(
-            evaluator,
-            substitution_state,
-            substitution_context.withTarget(plan.target),
-            plan,
-            &input,
-            frame,
-        );
+                evaluator,
+                substitution_state,
+                substitution_context.withTarget(plan.target),
+                plan,
+                &input,
+                frame,
+            );
         },
         .compound => |plan| blk: {
             var input = EvaluationInput.empty();
             break :blk evaluateCompoundPlanWithInput(
-            evaluator,
-            substitution_state,
-            substitution_context.withTarget(plan.target),
-            plan,
-            &input,
-            frame,
-        );
+                evaluator,
+                substitution_state,
+                substitution_context.withTarget(plan.target),
+                plan,
+                &input,
+                frame,
+            );
         },
         .pipeline => |plan| evaluatePipelinePlanWithFrame(
             evaluator,
@@ -5230,24 +5226,24 @@ fn evaluateCommandSubstitutionBodyPayload(
         .simple => |plan| blk: {
             var input = EvaluationInput.empty();
             break :blk evaluatePlanWithInput(
-            evaluator,
-            substitution_state,
-            substitution_context.withTarget(plan.target),
-            plan,
-            &input,
-            frame,
-        );
+                evaluator,
+                substitution_state,
+                substitution_context.withTarget(plan.target),
+                plan,
+                &input,
+                frame,
+            );
         },
         .compound => |plan| blk: {
             var input = EvaluationInput.empty();
             break :blk evaluateCompoundPlanWithInput(
-            evaluator,
-            substitution_state,
-            substitution_context.withTarget(plan.target),
-            plan,
-            &input,
-            frame,
-        );
+                evaluator,
+                substitution_state,
+                substitution_context.withTarget(plan.target),
+                plan,
+                &input,
+                frame,
+            );
         },
         .pipeline => |plan| evaluatePipelinePlanWithFrame(
             evaluator,

--- a/src/shell/state.zig
+++ b/src/shell/state.zig
@@ -8,6 +8,7 @@ const command_plan = @import("command_plan.zig");
 const context = @import("context.zig");
 const runtime_process = @import("../runtime/process.zig");
 const trap_semantics = @import("trap.zig");
+const expand = @import("expand.zig");
 
 pub const ExitStatus = u8;
 pub const TrapSignal = trap_semantics.Signal;
@@ -221,7 +222,6 @@ pub const VariableAttributes = struct {
     readonly: bool = false,
 };
 
-
 pub const Variable = struct {
     value: []const u8,
     exported: bool = false,
@@ -430,6 +430,12 @@ pub const BackgroundJobNotification = struct {
     }
 };
 
+fn shellStateLookup(ctx: ?*const anyopaque, name: []const u8) ?[]const u8 {
+    const state: *const ShellState = @ptrCast(@alignCast(ctx.?));
+    const vr = state.getVariable(name);
+    return if (vr) |v| v.value else null;
+}
+
 pub const ShellState = struct {
     allocator: std.mem.Allocator,
     scope: Scope = .current_shell,
@@ -459,6 +465,13 @@ pub const ShellState = struct {
         idle,
         running,
     };
+
+    pub fn envLookup(self: *const ShellState) expand.EnvLookup {
+        return .{
+            .context = self,
+            .lookupFn = shellStateLookup,
+        };
+    }
 
     pub fn init(allocator: std.mem.Allocator) ShellState {
         return .{ .allocator = allocator };


### PR DESCRIPTION
This enables the ability to tab complete when `cd ~/<tab>` or `cat ~/<tab>`

https://github.com/user-attachments/assets/904de325-b4d9-48a9-85ae-76f613cc62ff

