### PR TITLE
Add back vi mode

### DIFF
--- a/src/editor/session.zig
+++ b/src/editor/session.zig
@@ -186,6 +186,7 @@ pub const LineSession = struct {
     history_search_matches: std.ArrayList(HistoryView.HistoryEntry) = .empty,
     history_search_selected: usize = 0,
     history_search_filters: HistorySearchFilters = .{},
+    history_search_direction: ViHistoryDirection = .backward,
     autosuggestion: ?HistoryView.HistoryEntry = null,
     vi_history_search_query: std.ArrayList(u8) = .empty,
     vi_last_history_search_pattern: std.ArrayList(u8) = .empty,
@@ -379,7 +380,7 @@ pub const LineSession = struct {
                     self.editor.buffer.deleteNext();
                 }
             },
-            .ctrl_r => try self.beginHistorySearch(),
+            .ctrl_r => try self.beginHistorySearch(.backward),
             .undo => try self.undoEdit(),
             .redo => try self.redoEdit(),
             .clear_screen => {
@@ -1519,8 +1520,7 @@ pub const LineSession = struct {
     /// user sees candidates while typing instead of a silent pending state.
     fn beginViHistorySearchUi(self: *LineSession, direction: ViHistoryDirection) !void {
         self.resetViCommandPrefix();
-        self.vi_last_history_search_direction = direction;
-        try self.beginHistorySearch();
+        try self.beginHistorySearch(direction);
         // Leave command mode so escape/cancel returns to a normal editing
         // surface; accept still leaves the matched line ready to edit.
         self.vi_state = .insert;
@@ -1948,7 +1948,7 @@ pub const LineSession = struct {
         try self.editor.buffer.insertText(pasted);
         self.completion_menu.clear(self.allocator);
         if (self.state == .history_search) {
-            if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+            if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
         }
     }
 
@@ -2209,14 +2209,15 @@ pub const LineSession = struct {
         return null;
     }
 
-    fn beginHistorySearch(self: *LineSession) !void {
+    fn beginHistorySearch(self: *LineSession, direction: ViHistoryDirection) !void {
         self.history_search_query.clearRetainingCapacity();
         self.history_search_original.clearRetainingCapacity();
         try self.history_search_original.appendSlice(self.allocator, self.editor.buffer.text());
         try self.history_search_query.appendSlice(self.allocator, self.editor.buffer.text());
         self.history_search_filters = .{};
+        self.history_search_direction = direction;
         self.state = .history_search;
-        try self.refreshHistorySearch(null);
+        try self.refreshCurrentHistorySearch(null);
         self.completion_menu.clear(self.allocator);
     }
 
@@ -2224,7 +2225,10 @@ pub const LineSession = struct {
         if (try self.handleHistorySearchFilterKey(event)) return;
         switch (event.key) {
             .enter => {
-                if (self.selectedHistorySearchMatch()) |entry| try self.editor.buffer.replace(entry.text);
+                if (self.selectedHistorySearchMatch()) |entry| {
+                    try self.editor.buffer.replace(entry.text);
+                    try self.rememberAcceptedViHistorySearch();
+                }
                 self.finishHistorySearch();
             },
             .tab => if (event.modifiers.shift)
@@ -2239,16 +2243,16 @@ pub const LineSession = struct {
             .up => self.selectPreviousHistorySearchMatch(),
             .backspace => {
                 self.editor.buffer.deletePrevious();
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             .delete => {
                 self.editor.buffer.deleteNext();
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             .text => {
                 if (event.text.len == 0) return;
                 try self.editor.handleKey(event);
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             .left, .right, .home, .end, .word_left, .word_right => try self.editor.handleKey(event),
             .argument_left => self.editor.buffer.cursor_byte = try previousShellArgumentStart(
@@ -2263,19 +2267,19 @@ pub const LineSession = struct {
             ),
             .delete_to_start => {
                 self.editor.buffer.deleteToStart();
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             .delete_to_end => {
                 self.editor.buffer.deleteToEnd();
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             .delete_previous_word => {
                 self.editor.buffer.deletePreviousWord();
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             .delete_next_word => {
                 self.editor.buffer.deleteNextWord();
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             .delete_previous_argument => {
                 const start = try previousShellArgumentStart(
@@ -2284,7 +2288,7 @@ pub const LineSession = struct {
                     self.editor.buffer.cursor_byte,
                 );
                 try self.editor.buffer.replaceRange(start, self.editor.buffer.cursor_byte, "");
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             .delete_next_argument => {
                 const end = try nextShellArgumentEnd(
@@ -2293,7 +2297,7 @@ pub const LineSession = struct {
                     self.editor.buffer.cursor_byte,
                 );
                 try self.editor.buffer.replaceRange(self.editor.buffer.cursor_byte, end, "");
-                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshHistorySearch(null);
+                if (try self.syncHistorySearchQueryFromBuffer()) try self.refreshCurrentHistorySearch(null);
             },
             else => {},
         }
@@ -2308,7 +2312,7 @@ pub const LineSession = struct {
             't', 'T' => self.history_search_filters.session = !self.history_search_filters.session,
             else => return false,
         }
-        try self.refreshHistorySearch(null);
+        try self.refreshCurrentHistorySearch(null);
         return true;
     }
 
@@ -2317,6 +2321,13 @@ pub const LineSession = struct {
         self.history_search_query.clearRetainingCapacity();
         try self.history_search_query.appendSlice(self.allocator, self.editor.buffer.text());
         return true;
+    }
+
+    fn refreshCurrentHistorySearch(self: *LineSession, cursor: ?i64) !void {
+        return switch (self.history_search_direction) {
+            .backward => self.refreshHistorySearch(cursor),
+            .forward => self.refreshHistorySearchNext(cursor),
+        };
     }
 
     fn refreshHistorySearch(self: *LineSession, before: ?i64) !void {
@@ -2383,17 +2394,14 @@ pub const LineSession = struct {
         self.history_search_matches.clearRetainingCapacity();
     }
 
+    fn rememberAcceptedViHistorySearch(self: *LineSession) !void {
+        if (self.editing_mode != .vi or self.history_search_query.items.len == 0) return;
+        self.vi_last_history_search_pattern.clearRetainingCapacity();
+        try self.vi_last_history_search_pattern.appendSlice(self.allocator, self.history_search_query.items);
+        self.vi_last_history_search_direction = self.history_search_direction;
+    }
+
     fn finishHistorySearch(self: *LineSession) void {
-        // Remember the accepted query so vi n/N can still walk matches after
-        // leaving the shared history-search TUI.
-        if (self.editing_mode == .vi and self.history_search_query.items.len != 0) {
-            self.vi_last_history_search_pattern.clearRetainingCapacity();
-            // ziglint-ignore: Z026 best-effort pattern capture for n/N after TUI accept/cancel
-            self.vi_last_history_search_pattern.appendSlice(self.allocator, self.history_search_query.items) catch {};
-            if (self.vi_last_history_search_direction == null) {
-                self.vi_last_history_search_direction = .backward;
-            }
-        }
         self.clearHistorySearchMatches();
         self.history_search_query.clearRetainingCapacity();
         self.history_search_original.clearRetainingCapacity();
@@ -4090,6 +4098,70 @@ test "vi slash opens shared history search TUI" {
     try std.testing.expectEqual(LineSession.State.editing, session.state);
     try std.testing.expectEqualStrings("git commit --amend", session.editor.buffer.text());
     try std.testing.expectEqualStrings("git", session.vi_last_history_search_pattern.items);
+}
+
+test "vi question mark opens forward shared history search TUI" {
+    const entries = [_][]const u8{ "echo one", "git status", "echo two", "git commit --amend" };
+    var history_search: TestHistorySearch = .{ .entries = &entries };
+    var session = try LineSession.initWithEditingMode(
+        std.testing.allocator,
+        .{ .bytes = "$ " },
+        .{
+            .entries = &entries,
+            .context = &history_search,
+            .search = testSearchHistoryEntry,
+            .search_next = testSearchNextHistoryEntry,
+        },
+        .vi,
+    );
+    defer session.deinit();
+
+    try session.handleKey(.{ .key = .escape });
+    try session.handleKey(.{ .key = .text, .text = "?" });
+    try applyTestHistoryRequests(&session);
+
+    try session.handleKey(.{ .key = .text, .text = "git" });
+    try applyTestHistoryRequests(&session);
+    try std.testing.expect(session.history_search_matches.items.len != 0);
+
+    try session.handleKey(.{ .key = .enter });
+    try std.testing.expectEqual(LineSession.State.editing, session.state);
+    try std.testing.expectEqualStrings("git status", session.editor.buffer.text());
+    try std.testing.expectEqualStrings("git", session.vi_last_history_search_pattern.items);
+    try std.testing.expectEqual(ViHistoryDirection.forward, session.vi_last_history_search_direction.?);
+}
+
+test "canceling vi shared history search preserves previous repeat pattern" {
+    const entries = [_][]const u8{ "echo one", "git status", "echo two", "git commit --amend" };
+    var history_search: TestHistorySearch = .{ .entries = &entries };
+    var session = try LineSession.initWithEditingMode(
+        std.testing.allocator,
+        .{ .bytes = "$ " },
+        .{
+            .entries = &entries,
+            .context = &history_search,
+            .search = testSearchHistoryEntry,
+            .search_next = testSearchNextHistoryEntry,
+        },
+        .vi,
+    );
+    defer session.deinit();
+
+    try session.vi_last_history_search_pattern.appendSlice(std.testing.allocator, "git");
+    session.vi_last_history_search_direction = .forward;
+    try session.editor.buffer.replace("draft command");
+
+    try session.handleKey(.{ .key = .escape });
+    try session.handleKey(.{ .key = .text, .text = "/" });
+    try applyTestHistoryRequests(&session);
+    try session.handleKey(.{ .key = .text, .text = "echo" });
+    try applyTestHistoryRequests(&session);
+    try session.handleKey(.{ .key = .escape });
+
+    try std.testing.expectEqual(LineSession.State.editing, session.state);
+    try std.testing.expectEqualStrings("draft command", session.editor.buffer.text());
+    try std.testing.expectEqualStrings("git", session.vi_last_history_search_pattern.items);
+    try std.testing.expectEqual(ViHistoryDirection.forward, session.vi_last_history_search_direction.?);
 }
 
 const TestViAliasSet = struct {

--- a/src/editor/session.zig
+++ b/src/editor/session.zig
@@ -774,8 +774,12 @@ pub const LineSession = struct {
             'k', '-' => try self.viHistoryPrevious(self.takeViCountOrDefault(1)),
             'j', '+' => try self.viHistoryNext(self.takeViCountOrDefault(1)),
             'G' => try self.viHistoryOldestOrNumber(self.vi_count),
-            '/' => self.beginViHistorySearch(.backward),
-            '?' => self.beginViHistorySearch(.forward),
+            // Open the shared history-search TUI (same menu as emacs Ctrl-R).
+            // The silent POSIX /? prompt path remains available via n/N after a
+            // successful search that stored a last pattern, and for pure unit
+            // tests of the pattern walker.
+            '/' => try self.beginViHistorySearchUi(.backward),
+            '?' => try self.beginViHistorySearchUi(.forward),
             'n' => try self.repeatViHistorySearch(false),
             'N' => try self.repeatViHistorySearch(true),
             '@' => self.vi_pending = .alias,
@@ -1509,6 +1513,17 @@ pub const LineSession = struct {
         self.vi_history_search_query.clearRetainingCapacity();
         self.vi_pending = .{ .history_search = direction };
         self.completion_menu.clear(self.allocator);
+    }
+
+    /// Interactive vi history search: reuse the emacs-style match menu so the
+    /// user sees candidates while typing instead of a silent pending state.
+    fn beginViHistorySearchUi(self: *LineSession, direction: ViHistoryDirection) !void {
+        self.resetViCommandPrefix();
+        self.vi_last_history_search_direction = direction;
+        try self.beginHistorySearch();
+        // Leave command mode so escape/cancel returns to a normal editing
+        // surface; accept still leaves the matched line ready to edit.
+        self.vi_state = .insert;
     }
 
     fn handleViHistorySearchKey(self: *LineSession, direction: ViHistoryDirection, event: KeyEvent) !void {
@@ -2369,6 +2384,16 @@ pub const LineSession = struct {
     }
 
     fn finishHistorySearch(self: *LineSession) void {
+        // Remember the accepted query so vi n/N can still walk matches after
+        // leaving the shared history-search TUI.
+        if (self.editing_mode == .vi and self.history_search_query.items.len != 0) {
+            self.vi_last_history_search_pattern.clearRetainingCapacity();
+            // ziglint-ignore: Z026 best-effort pattern capture for n/N after TUI accept/cancel
+            self.vi_last_history_search_pattern.appendSlice(self.allocator, self.history_search_query.items) catch {};
+            if (self.vi_last_history_search_direction == null) {
+                self.vi_last_history_search_direction = .backward;
+            }
+        }
         self.clearHistorySearchMatches();
         self.history_search_query.clearRetainingCapacity();
         self.history_search_original.clearRetainingCapacity();
@@ -3992,8 +4017,9 @@ test "vi line session searches history with POSIX patterns and n N" {
     );
     defer session.deinit();
 
+    // Silent POSIX pattern path (still used by n/N and pure unit coverage).
     try session.handleKey(.{ .key = .escape });
-    try session.handleKey(.{ .key = .text, .text = "/" });
+    session.beginViHistorySearch(.backward);
     try session.handleKey(.{ .key = .text, .text = "git *" });
     try session.handleKey(.{ .key = .enter });
     try std.testing.expectEqualStrings("git commit --amend", session.editor.buffer.text());
@@ -4005,7 +4031,7 @@ test "vi line session searches history with POSIX patterns and n N" {
     try session.handleKey(.{ .key = .text, .text = "N" });
     try std.testing.expectEqualStrings("git commit --amend", session.editor.buffer.text());
 
-    try session.handleKey(.{ .key = .text, .text = "/" });
+    session.beginViHistorySearch(.backward);
     try session.handleKey(.{ .key = .text, .text = "^echo" });
     try session.handleKey(.{ .key = .enter });
     try std.testing.expectEqualStrings("echo two", session.editor.buffer.text());
@@ -4025,13 +4051,45 @@ test "vi line session question mark searches history forward" {
     try session.handleKey(.{ .key = .text, .text = "G" });
     try std.testing.expectEqualStrings("echo one", session.editor.buffer.text());
 
-    try session.handleKey(.{ .key = .text, .text = "?" });
+    session.beginViHistorySearch(.forward);
     try session.handleKey(.{ .key = .text, .text = "git*" });
     try session.handleKey(.{ .key = .enter });
     try std.testing.expectEqualStrings("git status", session.editor.buffer.text());
 
     try session.handleKey(.{ .key = .text, .text = "n" });
     try std.testing.expectEqualStrings("git commit --amend", session.editor.buffer.text());
+}
+
+test "vi slash opens shared history search TUI" {
+    const entries = [_][]const u8{ "echo one", "git status", "echo two", "git commit --amend" };
+    var history_search: TestHistorySearch = .{ .entries = &entries };
+    var session = try LineSession.initWithEditingMode(
+        std.testing.allocator,
+        .{ .bytes = "$ " },
+        .{
+            .entries = &entries,
+            .context = &history_search,
+            .search = testSearchHistoryEntry,
+            .search_next = testSearchNextHistoryEntry,
+        },
+        .vi,
+    );
+    defer session.deinit();
+
+    try session.handleKey(.{ .key = .escape });
+    try session.handleKey(.{ .key = .text, .text = "/" });
+    try std.testing.expectEqual(LineSession.State.history_search, session.state);
+    try std.testing.expectEqual(ViState.insert, session.vi_state);
+    try applyTestHistoryRequests(&session);
+
+    try session.handleKey(.{ .key = .text, .text = "git" });
+    try applyTestHistoryRequests(&session);
+    try std.testing.expect(session.history_search_matches.items.len != 0);
+
+    try session.handleKey(.{ .key = .enter });
+    try std.testing.expectEqual(LineSession.State.editing, session.state);
+    try std.testing.expectEqualStrings("git commit --amend", session.editor.buffer.text());
+    try std.testing.expectEqualStrings("git", session.vi_last_history_search_pattern.items);
 }
 
 const TestViAliasSet = struct {

--- a/src/interactive.zig
+++ b/src/interactive.zig
@@ -230,6 +230,9 @@ const InteractiveSession = struct {
         return terminal.readLine(.{
             .prompt = prompt_text,
             .right_prompt = right_prompt_text,
+            // Read shell option state each prompt so `set -o vi` / `set -o emacs`
+            // take effect on the next line without restarting the session.
+            .editing_mode = if (self.sh.state.options.vi) .vi else .emacs,
             .history = self.history_service.lineEditorView(self.io),
             .prompt_async_context = self,
             .pump_prompt_async = pumpPromptAsync,

--- a/src/shell/builtin.zig
+++ b/src/shell/builtin.zig
@@ -2196,6 +2196,7 @@ fn variableLessThan(_: void, lhs: state_mod.Variable, rhs: state_mod.Variable) b
 
 const SetOption = enum {
     allexport,
+    emacs,
     errexit,
     hashall,
     noclobber,
@@ -2204,12 +2205,14 @@ const SetOption = enum {
     notify,
     nounset,
     pipefail,
+    vi,
     verbose,
     xtrace,
 };
 
 const set_option_names = std.StaticStringMap(SetOption).initComptime(.{
     .{ "allexport", .allexport },
+    .{ "emacs", .emacs },
     .{ "errexit", .errexit },
     .{ "hashall", .hashall },
     .{ "noclobber", .noclobber },
@@ -2218,12 +2221,14 @@ const set_option_names = std.StaticStringMap(SetOption).initComptime(.{
     .{ "notify", .notify },
     .{ "nounset", .nounset },
     .{ "pipefail", .pipefail },
+    .{ "vi", .vi },
     .{ "verbose", .verbose },
     .{ "xtrace", .xtrace },
 });
 
 const set_option_order = [_]SetOption{
     .allexport,
+    .emacs,
     .errexit,
     .hashall,
     .noclobber,
@@ -2232,6 +2237,7 @@ const set_option_order = [_]SetOption{
     .notify,
     .nounset,
     .pipefail,
+    .vi,
     .verbose,
     .xtrace,
 };
@@ -2239,6 +2245,7 @@ const set_option_order = [_]SetOption{
 fn setOptionName(option: SetOption) []const u8 {
     return switch (option) {
         .allexport => "allexport",
+        .emacs => "emacs",
         .errexit => "errexit",
         .hashall => "hashall",
         .noclobber => "noclobber",
@@ -2247,6 +2254,7 @@ fn setOptionName(option: SetOption) []const u8 {
         .notify => "notify",
         .nounset => "nounset",
         .pipefail => "pipefail",
+        .vi => "vi",
         .verbose => "verbose",
         .xtrace => "xtrace",
     };
@@ -2255,6 +2263,7 @@ fn setOptionName(option: SetOption) []const u8 {
 fn setOptionEnabled(shell: anytype, option: SetOption) bool {
     return switch (option) {
         .allexport => shell.state.options.allexport,
+        .emacs => shell.state.options.emacs,
         .errexit => shell.state.options.errexit,
         .hashall => shell.state.options.hashall,
         .noclobber => shell.state.options.noclobber,
@@ -2263,6 +2272,7 @@ fn setOptionEnabled(shell: anytype, option: SetOption) bool {
         .notify => shell.state.options.notify,
         .nounset => shell.state.options.nounset,
         .pipefail => shell.state.options.pipefail,
+        .vi => shell.state.options.vi,
         .verbose => shell.state.options.verbose,
         .xtrace => shell.state.options.xtrace,
     };
@@ -2293,6 +2303,13 @@ fn setNamedOption(shell: anytype, name: []const u8, enabled: bool) bool {
     const option = set_option_names.get(name) orelse return false;
     switch (option) {
         .allexport => shell.state.options.allexport = enabled,
+        .emacs => {
+            // Emacs-style editing is Rush's default interactive mode. Enabling
+            // it clears vi; disabling it only clears the explicit option bit
+            // and does not enable vi.
+            shell.state.options.emacs = enabled;
+            if (enabled) shell.state.options.vi = false;
+        },
         .errexit => shell.state.options.errexit = enabled,
         .hashall => shell.state.options.hashall = enabled,
         .noclobber => shell.state.options.noclobber = enabled,
@@ -2301,6 +2318,12 @@ fn setNamedOption(shell: anytype, name: []const u8, enabled: bool) bool {
         .notify => shell.state.options.notify = enabled,
         .nounset => shell.state.options.nounset = enabled,
         .pipefail => shell.state.options.pipefail = enabled,
+        .vi => {
+            // POSIX vi editing mode. Enabling it turns off emacs; disabling it
+            // restores Rush's default emacs-style editing option.
+            shell.state.options.vi = enabled;
+            shell.state.options.emacs = !enabled;
+        },
         .verbose => shell.state.options.verbose = enabled,
         .xtrace => shell.state.options.xtrace = enabled,
     }
@@ -3105,6 +3128,83 @@ test "set -o notify toggles notify option" {
         (try eval(&shell, set_definition, &.{ "set", "+o", "notify" })).status,
     );
     try std.testing.expect(!shell.state.options.notify);
+}
+
+test "set -o vi and emacs are mutually exclusive editing options" {
+    const TestHost = struct {
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn writeAll(_: *@This(), _: host.Fd, _: []const u8) !void {}
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn setFileCreationMask(_: *@This(), mask: u32) u32 {
+            return mask;
+        }
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn currentProcessId(_: *@This()) host.Pid {
+            return 1;
+        }
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn sendSignal(_: *@This(), _: host.Pid, _: u8) !void {}
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn setSignalDefault(_: *@This(), _: u8) !void {}
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn setSignalIgnored(_: *@This(), _: u8) !void {}
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn installSignalTrap(_: *@This(), _: u8) !void {}
+    };
+    const TestShell = struct {
+        host: TestHost = .{},
+        state: state_mod.State,
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        fn scratchAllocator(_: *@This()) std.mem.Allocator {
+            return std.testing.allocator;
+        }
+    };
+
+    var shell: TestShell = .{ .state = state_mod.State.init(std.testing.allocator, .{}) };
+    defer shell.state.deinit();
+    const set_definition = lookup("set").?;
+
+    try std.testing.expect(shell.state.options.emacs);
+    try std.testing.expect(!shell.state.options.vi);
+
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "-o", "vi" })).status,
+    );
+    try std.testing.expect(shell.state.options.vi);
+    try std.testing.expect(!shell.state.options.emacs);
+
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "+o", "vi" })).status,
+    );
+    try std.testing.expect(!shell.state.options.vi);
+    try std.testing.expect(shell.state.options.emacs);
+
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "-o", "vi" })).status,
+    );
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "-o", "emacs" })).status,
+    );
+    try std.testing.expect(shell.state.options.emacs);
+    try std.testing.expect(!shell.state.options.vi);
+
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "+o", "emacs" })).status,
+    );
+    try std.testing.expect(!shell.state.options.emacs);
+    try std.testing.expect(!shell.state.options.vi);
 }
 
 test "jobs builtin filters jobs and prints pids" {

--- a/src/shell/state.zig
+++ b/src/shell/state.zig
@@ -16,6 +16,9 @@ pub const Mode = enum {
 pub const Options = struct {
     mode: Mode = .bash,
     allexport: bool = false,
+    /// Implementation-extension Emacs-style line editing. On by default and
+    /// mutually exclusive with `vi` when either option is enabled.
+    emacs: bool = true,
     errexit: bool = false,
     hashall: bool = false,
     nounset: bool = false,
@@ -25,6 +28,9 @@ pub const Options = struct {
     pipefail: bool = false,
     notify: bool = false,
     verbose: bool = false,
+    /// POSIX vi command-line editing for the interactive line editor.
+    /// Mutually exclusive with `emacs` when either option is enabled.
+    vi: bool = false,
     expand_aliases: bool = false,
     xtrace: bool = false,
     monitor: bool = false,

--- a/tests/posix/special_builtins.zon
+++ b/tests/posix/special_builtins.zon
@@ -606,6 +606,33 @@
             .status = 0,
         },
         .{
+            .name = "set -o vi and emacs toggle editing options",
+            .script =
+            \\set -o | grep '^emacs[[:space:]]*on' >/dev/null && set -o | grep '^vi[[:space:]]*off' >/dev/null && printf 'defaults\n'
+            \\set -o vi
+            \\set -o | grep '^vi[[:space:]]*on' >/dev/null && set -o | grep '^emacs[[:space:]]*off' >/dev/null && printf 'vi-on\n'
+            \\set +o | grep '^set -o vi$' >/dev/null && set +o | grep '^set +o emacs$' >/dev/null && printf 'vi-reusable\n'
+            \\set +o vi
+            \\set -o | grep '^vi[[:space:]]*off' >/dev/null && set -o | grep '^emacs[[:space:]]*on' >/dev/null && printf 'vi-off\n'
+            \\set -o vi
+            \\set -o emacs
+            \\set -o | grep '^emacs[[:space:]]*on' >/dev/null && set -o | grep '^vi[[:space:]]*off' >/dev/null && printf 'emacs-on\n'
+            \\set +o emacs
+            \\set -o | grep '^emacs[[:space:]]*off' >/dev/null && set -o | grep '^vi[[:space:]]*off' >/dev/null && printf 'emacs-off\n'
+            ,
+            .stdout =
+            \\defaults
+            \\vi-on
+            \\vi-reusable
+            \\vi-off
+            \\emacs-on
+            \\emacs-off
+            \\
+            ,
+            .stderr = "",
+            .status = 0,
+        },
+        .{
             .name = "set without operands lists shell variables",
             .script =
             \\zeta=last

--- a/website/docs/builtins/set.html
+++ b/website/docs/builtins/set.html
@@ -44,6 +44,7 @@
       <tr><td><code>-a</code></td><td><code>allexport</code></td><td>Export variables assigned afterward.</td></tr>
       <tr><td><code>-b</code></td><td><code>notify</code></td><td>Report completed background jobs without waiting for the next prompt.</td></tr>
       <tr><td><code>-C</code></td><td><code>noclobber</code></td><td>Prevent ordinary output redirections from replacing existing regular files.</td></tr>
+      <tr><td>-</td><td><code>emacs</code></td><td>Use Emacs-style interactive line editing. On by default; mutually exclusive with <code>vi</code>.</td></tr>
       <tr><td><code>-e</code></td><td><code>errexit</code></td><td>Exit after an untested command failure.</td></tr>
       <tr><td><code>-f</code></td><td><code>noglob</code></td><td>Disable pathname expansion.</td></tr>
       <tr><td><code>-h</code></td><td><code>hashall</code></td><td>Remember command paths as commands are found.</td></tr>
@@ -52,11 +53,13 @@
       <tr><td>-</td><td><code>pipefail</code></td><td>Use the rightmost non-zero pipeline status, or zero if all commands succeed.</td></tr>
       <tr><td><code>-u</code></td><td><code>nounset</code></td><td>Treat expansion of unset parameters as an error where required by the shell language.</td></tr>
       <tr><td><code>-v</code></td><td><code>verbose</code></td><td>Write shell input as it is read.</td></tr>
+      <tr><td>-</td><td><code>vi</code></td><td>Use POSIX vi interactive line editing. Mutually exclusive with <code>emacs</code>.</td></tr>
       <tr><td><code>-x</code></td><td><code>xtrace</code></td><td>Trace expanded commands before execution.</td></tr>
     </tbody>
   </table>
 
   <p>Use <code>set -o name</code> or <code>set +o name</code> to enable or disable a named option. Short options may be combined.</p>
+  <p><code>emacs</code> is Rush's default interactive editing mode and an implementation extension: POSIX.1-2024 does not standardize shell Emacs bindings. <code>set -o vi</code> enables vi mode and disables <code>emacs</code>; <code>set +o vi</code> restores the default Emacs-style option. <code>set +o emacs</code> clears the explicit Emacs option without enabling <code>vi</code>.</p>
 
   <h2 id="exit-status"><a href="#exit-status">EXIT STATUS</a></h2>
 


### PR DESCRIPTION
I noticed the vi mode wasn't working, it appears it was (inadvertently?) dropped after a refactor. This adds it back and also surfaces the same search UI as Ctrl-R in emacs mode. I'm not sure if the latter is desired behavior, but having some UI like the other mode seemed nice.

Disclaimer: this was fully vibe coded with grok on amp

https://ampcode.com/threads/T-019f63db-7fae-71ef-9d8d-e43299d94cb2 (ignore the side convo about the hang, PEBKAC)