### PR TITLE
Vi mode fixes

### DIFF
--- a/src/editor/session.zig
+++ b/src/editor/session.zig
@@ -734,10 +734,11 @@ pub const LineSession = struct {
                 self.editor.buffer.cursor_byte,
             ) and !self.vi_replaying_repeat) try self.setViLastRepeat(.delete_to_end),
             'C' => {
-                _ = try self.viDeleteRange(
+                _ = try self.viDeleteRangeForState(
                     self.editor.buffer.cursor_byte,
                     self.editor.buffer.text().len,
                     self.editor.buffer.cursor_byte,
+                    .insert,
                 );
                 try self.beginViInsertRepeat(.change_to_end);
                 self.enterViInsertModeAtCursor();
@@ -1070,10 +1071,11 @@ pub const LineSession = struct {
                 self.editor.buffer.cursor_byte,
             ),
             .change_to_end => |input| {
-                _ = try self.viDeleteRange(
+                _ = try self.viDeleteRangeForState(
                     self.editor.buffer.cursor_byte,
                     self.editor.buffer.text().len,
                     self.editor.buffer.cursor_byte,
+                    .insert,
                 );
                 try self.applyViInputRepeat(input, .insert);
                 self.finishViInputRepeat(input);
@@ -1100,7 +1102,7 @@ pub const LineSession = struct {
                     operator.count,
                     motion,
                 );
-                if (!try self.viDeleteRange(range.start, range.end, range.cursor_after_delete)) return;
+                if (!try self.viDeleteRangeForState(range.start, range.end, range.cursor_after_delete, .insert)) return;
                 try self.applyViInputRepeat(operator.input, .insert);
                 self.finishViInputRepeat(operator.input);
             },
@@ -1208,7 +1210,10 @@ pub const LineSession = struct {
                     .count = count,
                 } }),
             .change => {
-                if (!try self.viDeleteRange(range.start, range.end, range.cursor_after_delete)) return;
+                // Change enters insert mode next, so keep the post-delete cursor at
+                // the insertion point even when that is one past the last character
+                // (for example, `cw` on the final word leaves following blanks intact).
+                if (!try self.viDeleteRangeForState(range.start, range.end, range.cursor_after_delete, .insert)) return;
                 try self.beginViInsertRepeat(.{ .operator_change = .{
                     .motion_command = motion_command,
                     .count = count,
@@ -1366,13 +1371,24 @@ pub const LineSession = struct {
     }
 
     fn viDeleteRange(self: *LineSession, start: usize, end: usize, cursor_after_delete: usize) !bool {
+        return self.viDeleteRangeForState(start, end, cursor_after_delete, self.vi_state);
+    }
+
+    fn viDeleteRangeForState(
+        self: *LineSession,
+        start: usize,
+        end: usize,
+        cursor_after_delete: usize,
+        state_after_delete: ViState,
+    ) !bool {
         if (start >= end) return false;
         try self.saveViUndo();
         self.kill_ring.clearRetainingCapacity();
         try self.kill_ring.appendSlice(self.allocator, self.editor.buffer.text()[start..end]);
         try self.editor.buffer.replaceRange(start, end, "");
         self.editor.buffer.cursor_byte = @min(cursor_after_delete, self.editor.buffer.text().len);
-        if (self.vi_state == .command and self.editor.buffer.cursor_byte == self.editor.buffer.text().len) {
+        // Command mode cannot rest on the one-past-end slot; insert/replace may.
+        if (state_after_delete == .command and self.editor.buffer.cursor_byte == self.editor.buffer.text().len) {
             self.editor.buffer.moveLeft();
         }
         self.completion_menu.clear(self.allocator);
@@ -3765,7 +3781,6 @@ test "vi line session switches modes and edits in command mode" {
     try session.handleKey(.{ .key = .text, .text = "B" });
     try std.testing.expectEqualStrings("aBbc", session.editor.buffer.text());
 }
-
 test "vi insert mode inserts newline on shift-enter and kills next word" {
     var session = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
     defer session.deinit();
@@ -3973,6 +3988,31 @@ test "vi line session repeats operator changes and preserves change-word blanks"
     try blank.handleKey(.{ .key = .text, .text = "X" });
     try blank.handleKey(.{ .key = .escape });
     try std.testing.expectEqualStrings("oneX two", blank.editor.buffer.text());
+
+    // When the next word is a single character at EOL, w lands on lastGraphemeStart.
+    // cw must still act like ce and preserve the blank before that word.
+    var short_last = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
+    defer short_last.deinit();
+    try short_last.handleKey(.{ .key = .text, .text = "a b" });
+    try short_last.handleKey(.{ .key = .escape });
+    try short_last.handleKey(.{ .key = .text, .text = "0" });
+    try short_last.handleKey(.{ .key = .text, .text = "c" });
+    try short_last.handleKey(.{ .key = .text, .text = "w" });
+    try short_last.handleKey(.{ .key = .text, .text = "X" });
+    try short_last.handleKey(.{ .key = .escape });
+    try std.testing.expectEqualStrings("X b", short_last.editor.buffer.text());
+
+    // cw on the final word should replace only that word.
+    var last_word = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
+    defer last_word.deinit();
+    try last_word.handleKey(.{ .key = .text, .text = "hello world" });
+    try last_word.handleKey(.{ .key = .escape });
+    try last_word.handleKey(.{ .key = .text, .text = "b" });
+    try last_word.handleKey(.{ .key = .text, .text = "c" });
+    try last_word.handleKey(.{ .key = .text, .text = "w" });
+    try last_word.handleKey(.{ .key = .text, .text = "X" });
+    try last_word.handleKey(.{ .key = .escape });
+    try std.testing.expectEqualStrings("hello X", last_word.editor.buffer.text());
 }
 
 test "vi line session leaves out-of-range operator motions unchanged" {

--- a/src/editor/session.zig
+++ b/src/editor/session.zig
@@ -96,6 +96,7 @@ const viMacroKeyEvent = vi.viMacroKeyEvent;
 const viHistoryPatternMatches = vi.viHistoryPatternMatches;
 const viMotion = vi.viMotion;
 const viOperatorMotionRange = vi.viOperatorMotionRange;
+const viChangeWordMotionRange = vi.viChangeWordMotionRange;
 const multiplyViCounts = vi.multiplyViCounts;
 const firstNonBlank = vi.firstNonBlank;
 const previousViWordStart = vi.previousViWordStart;
@@ -734,11 +735,11 @@ pub const LineSession = struct {
                 self.editor.buffer.cursor_byte,
             ) and !self.vi_replaying_repeat) try self.setViLastRepeat(.delete_to_end),
             'C' => {
-                _ = try self.viDeleteRangeForState(
+                _ = try self.viDeleteRangeWithCursorPolicy(
                     self.editor.buffer.cursor_byte,
                     self.editor.buffer.text().len,
                     self.editor.buffer.cursor_byte,
-                    .insert,
+                    false,
                 );
                 try self.beginViInsertRepeat(.change_to_end);
                 self.enterViInsertModeAtCursor();
@@ -1074,11 +1075,11 @@ pub const LineSession = struct {
                 self.editor.buffer.cursor_byte,
             ),
             .change_to_end => |input| {
-                _ = try self.viDeleteRangeForState(
+                _ = try self.viDeleteRangeWithCursorPolicy(
                     self.editor.buffer.cursor_byte,
                     self.editor.buffer.text().len,
                     self.editor.buffer.cursor_byte,
-                    .insert,
+                    false,
                 );
                 try self.applyViInputRepeat(input, .insert);
                 self.finishViInputRepeat(input);
@@ -1091,21 +1092,13 @@ pub const LineSession = struct {
             },
             .operator_delete => |operator| try self.applyViOperator(.delete, operator.motion_command, operator.count),
             .operator_change => |operator| {
-                const motion = viMotion(
-                    self.editor.buffer.text(),
-                    self.editor.buffer.cursor_byte,
-                    operator.motion_command,
-                    operator.count,
-                ) orelse return;
-                const range = viOperatorMotionRange(
-                    self.editor.buffer.text(),
-                    self.editor.buffer.cursor_byte,
-                    .change,
-                    operator.motion_command,
-                    operator.count,
-                    motion,
-                );
-                if (!try self.viDeleteRangeForState(range.start, range.end, range.cursor_after_delete, .insert)) return;
+                const range = self.viOperatorRange(.change, operator.motion_command, operator.count) orelse return;
+                if (!try self.viDeleteRangeWithCursorPolicy(
+                    range.start,
+                    range.end,
+                    range.cursor_after_delete,
+                    false,
+                )) return;
                 try self.applyViInputRepeat(operator.input, .insert);
                 self.finishViInputRepeat(operator.input);
             },
@@ -1191,20 +1184,7 @@ pub const LineSession = struct {
             }
             return;
         }
-        const motion = viMotion(
-            self.editor.buffer.text(),
-            self.editor.buffer.cursor_byte,
-            motion_command,
-            count,
-        ) orelse return;
-        const range = viOperatorMotionRange(
-            self.editor.buffer.text(),
-            self.editor.buffer.cursor_byte,
-            operator,
-            motion_command,
-            count,
-            motion,
-        );
+        const range = self.viOperatorRange(operator, motion_command, count) orelse return;
         switch (operator) {
             .delete => if (try self.viDeleteRange(range.start, range.end, range.cursor_after_delete) and
                 !self.vi_replaying_repeat)
@@ -1213,10 +1193,14 @@ pub const LineSession = struct {
                     .count = count,
                 } }),
             .change => {
-                // Change enters insert mode next, so keep the post-delete cursor at
-                // the insertion point even when that is one past the last character
-                // (for example, `cw` on the final word leaves following blanks intact).
-                if (!try self.viDeleteRangeForState(range.start, range.end, range.cursor_after_delete, .insert)) return;
+                // Change enters insert next: do not clamp past EOL so the insertion
+                // point can sit after a preserved trailing blank (e.g. final-word cw).
+                if (!try self.viDeleteRangeWithCursorPolicy(
+                    range.start,
+                    range.end,
+                    range.cursor_after_delete,
+                    false,
+                )) return;
                 try self.beginViInsertRepeat(.{ .operator_change = .{
                     .motion_command = motion_command,
                     .count = count,
@@ -1225,6 +1209,37 @@ pub const LineSession = struct {
             },
             .yank => try self.viYankRange(range.start, range.end),
         }
+    }
+
+    /// Resolve an operator motion range. Change-word skips computing exclusive w/W.
+    fn viOperatorRange(
+        self: *LineSession,
+        operator: ViOperator,
+        motion_command: u21,
+        count: usize,
+    ) ?ViMotionRange {
+        if (operator == .change and (motion_command == 'w' or motion_command == 'W')) {
+            return viChangeWordMotionRange(
+                self.editor.buffer.text(),
+                self.editor.buffer.cursor_byte,
+                motion_command,
+                count,
+            );
+        }
+        const motion = viMotion(
+            self.editor.buffer.text(),
+            self.editor.buffer.cursor_byte,
+            motion_command,
+            count,
+        ) orelse return null;
+        return viOperatorMotionRange(
+            self.editor.buffer.text(),
+            self.editor.buffer.cursor_byte,
+            operator,
+            motion_command,
+            count,
+            motion,
+        );
     }
 
     fn applyViFind(self: *LineSession, find: ViFindCommand, count: usize) !void {
@@ -1373,16 +1388,21 @@ pub const LineSession = struct {
         return self.viDeleteRange(start, self.editor.buffer.cursor_byte, start);
     }
 
+    /// Delete `[start, end)` and clamp the cursor for command mode when it would
+    /// sit past the last character.
     fn viDeleteRange(self: *LineSession, start: usize, end: usize, cursor_after_delete: usize) !bool {
-        return self.viDeleteRangeForState(start, end, cursor_after_delete, self.vi_state);
+        return self.viDeleteRangeWithCursorPolicy(start, end, cursor_after_delete, true);
     }
 
-    fn viDeleteRangeForState(
+    /// Like `viDeleteRange`, but `clamp_to_command_cursor` controls whether a
+    /// post-delete end-of-line cursor is pulled left. Change operators pass
+    /// false because insert may legally sit at `len`.
+    fn viDeleteRangeWithCursorPolicy(
         self: *LineSession,
         start: usize,
         end: usize,
         cursor_after_delete: usize,
-        state_after_delete: ViState,
+        clamp_to_command_cursor: bool,
     ) !bool {
         if (start >= end) return false;
         try self.saveViUndo();
@@ -1390,8 +1410,7 @@ pub const LineSession = struct {
         try self.kill_ring.appendSlice(self.allocator, self.editor.buffer.text()[start..end]);
         try self.editor.buffer.replaceRange(start, end, "");
         self.editor.buffer.cursor_byte = @min(cursor_after_delete, self.editor.buffer.text().len);
-        // Command mode cannot rest on the one-past-end slot; insert/replace may.
-        if (state_after_delete == .command and self.editor.buffer.cursor_byte == self.editor.buffer.text().len) {
+        if (clamp_to_command_cursor and self.editor.buffer.cursor_byte == self.editor.buffer.text().len) {
             self.editor.buffer.moveLeft();
         }
         self.completion_menu.clear(self.allocator);

--- a/src/editor/session.zig
+++ b/src/editor/session.zig
@@ -3813,8 +3813,6 @@ test "vi leave-insert steps onto previous character" {
     // After typing at EOL, ESC lands on the last character.
     try std.testing.expectEqual(@as(usize, 3), session.editor.buffer.cursor_byte);
 
-    // i ESC does not change position when already on a character; a second
-    // i ESC steps left once more only when insert moved the cursor right.
     // Bare i ESC i ESC from mid-line: each ESC steps left from the insert point.
     try session.handleKey(.{ .key = .text, .text = "0" });
     try session.handleKey(.{ .key = .text, .text = "l" });

--- a/src/editor/session.zig
+++ b/src/editor/session.zig
@@ -906,7 +906,10 @@ pub const LineSession = struct {
     fn enterViCommandMode(self: *LineSession) void {
         self.vi_state = .command;
         self.resetViCommandPrefix();
-        if (self.editor.buffer.cursor_byte == self.editor.buffer.text().len) {
+        // Leaving insert/replace for command mode always steps onto the previous
+        // grapheme (classic vi). At column 0 the cursor stays put so `i`/`a` at
+        // the start of the line remain usable.
+        if (self.editor.buffer.cursor_byte != 0) {
             self.editor.buffer.moveLeft();
         }
         // ziglint-ignore: Z026 best-effort undo snapshot for mode transition
@@ -3781,6 +3784,42 @@ test "vi line session switches modes and edits in command mode" {
     try session.handleKey(.{ .key = .text, .text = "B" });
     try std.testing.expectEqualStrings("aBbc", session.editor.buffer.text());
 }
+
+test "vi leave-insert steps onto previous character" {
+    var session = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
+    defer session.deinit();
+
+    try session.handleKey(.{ .key = .text, .text = "abcd" });
+    try session.handleKey(.{ .key = .escape });
+    // After typing at EOL, ESC lands on the last character.
+    try std.testing.expectEqual(@as(usize, 3), session.editor.buffer.cursor_byte);
+
+    // i ESC does not change position when already on a character; a second
+    // i ESC steps left once more only when insert moved the cursor right.
+    // Bare i ESC i ESC from mid-line: each ESC steps left from the insert point.
+    try session.handleKey(.{ .key = .text, .text = "0" });
+    try session.handleKey(.{ .key = .text, .text = "l" });
+    try session.handleKey(.{ .key = .text, .text = "l" });
+    try std.testing.expectEqual(@as(usize, 2), session.editor.buffer.cursor_byte); // on 'c'
+    try session.handleKey(.{ .key = .text, .text = "i" });
+    try session.handleKey(.{ .key = .escape });
+    try std.testing.expectEqual(@as(usize, 1), session.editor.buffer.cursor_byte); // on 'b'
+    try session.handleKey(.{ .key = .text, .text = "i" });
+    try session.handleKey(.{ .key = .escape });
+    try std.testing.expectEqual(@as(usize, 0), session.editor.buffer.cursor_byte); // on 'a'
+
+    // a ESC a ESC leaves the cursor unmoved: append steps right, ESC steps left.
+    try session.handleKey(.{ .key = .text, .text = "l" });
+    try std.testing.expectEqual(@as(usize, 1), session.editor.buffer.cursor_byte);
+    try session.handleKey(.{ .key = .text, .text = "a" });
+    try session.handleKey(.{ .key = .escape });
+    try std.testing.expectEqual(@as(usize, 1), session.editor.buffer.cursor_byte);
+    try session.handleKey(.{ .key = .text, .text = "a" });
+    try session.handleKey(.{ .key = .escape });
+    try std.testing.expectEqual(@as(usize, 1), session.editor.buffer.cursor_byte);
+    try std.testing.expectEqualStrings("abcd", session.editor.buffer.text());
+}
+
 test "vi insert mode inserts newline on shift-enter and kills next word" {
     var session = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
     defer session.deinit();
@@ -3868,9 +3907,12 @@ test "vi line session repeats insert editing controls" {
     try counted.handleKey(.{ .key = .text, .text = "z" });
     try counted.handleKey(.{ .key = .escape });
     try std.testing.expectEqualStrings("xzxzab", counted.editor.buffer.text());
+    // ESC leaves the cursor on the last inserted character, so `.` replays at
+    // that column rather than after the insert.
+    try std.testing.expectEqual(@as(usize, 3), counted.editor.buffer.cursor_byte);
 
     try counted.handleKey(.{ .key = .text, .text = "." });
-    try std.testing.expectEqualStrings("xzxzxzxzab", counted.editor.buffer.text());
+    try std.testing.expectEqualStrings("xzxxzxzzab", counted.editor.buffer.text());
 
     var edited = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
     defer edited.deinit();
@@ -3884,9 +3926,11 @@ test "vi line session repeats insert editing controls" {
     try edited.handleKey(.{ .key = .text, .text = "three " });
     try edited.handleKey(.{ .key = .escape });
     try std.testing.expectEqualStrings("one three end", edited.editor.buffer.text());
+    // ESC steps onto the space before "end", so `.` replays from that column.
+    try std.testing.expectEqual(@as(usize, 9), edited.editor.buffer.cursor_byte);
 
     try edited.handleKey(.{ .key = .text, .text = "." });
-    try std.testing.expectEqualStrings("one three one three end", edited.editor.buffer.text());
+    try std.testing.expectEqualStrings("one threeone three  end", edited.editor.buffer.text());
 
     var moved = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
     defer moved.deinit();
@@ -3900,9 +3944,10 @@ test "vi line session repeats insert editing controls" {
     try moved.handleKey(.{ .key = .text, .text = "Z" });
     try moved.handleKey(.{ .key = .escape });
     try std.testing.expectEqualStrings("xZyab", moved.editor.buffer.text());
+    try std.testing.expectEqual(@as(usize, 1), moved.editor.buffer.cursor_byte);
 
     try moved.handleKey(.{ .key = .text, .text = "." });
-    try std.testing.expectEqualStrings("xZxZyyab", moved.editor.buffer.text());
+    try std.testing.expectEqualStrings("xxZyZyab", moved.editor.buffer.text());
 }
 
 test "vi line session repeats replace mode sessions" {
@@ -3916,9 +3961,11 @@ test "vi line session repeats replace mode sessions" {
     try session.handleKey(.{ .key = .text, .text = "XY" });
     try session.handleKey(.{ .key = .escape });
     try std.testing.expectEqualStrings("XYcdef", session.editor.buffer.text());
+    // ESC from replace lands on the last replaced character.
+    try std.testing.expectEqual(@as(usize, 1), session.editor.buffer.cursor_byte);
 
     try session.handleKey(.{ .key = .text, .text = "." });
-    try std.testing.expectEqualStrings("XYXYef", session.editor.buffer.text());
+    try std.testing.expectEqualStrings("XXYdef", session.editor.buffer.text());
 }
 
 test "vi line session multiplies operator and motion counts" {

--- a/src/editor/vi.zig
+++ b/src/editor/vi.zig
@@ -421,7 +421,8 @@ pub fn viOperatorMotionRange(
     motion: ViMotionResult,
 ) ViMotionRange {
     if (operator == .change and (motion_command == 'w' or motion_command == 'W')) {
-        return viChangeWordMotionRange(bytes, cursor_byte, motion_command, count, motion);
+        // Change-word ignores exclusive w/W: classic vi uses sticky end-of-word.
+        return viChangeWordMotionRange(bytes, cursor_byte, motion_command, count);
     }
     if ((motion_command == 'w' or motion_command == 'W') and
         motion.cursor == lastGraphemeStart(bytes) and
@@ -432,20 +433,14 @@ pub fn viOperatorMotionRange(
     return viMotionRange(bytes, cursor_byte, motion);
 }
 
+/// Range for `cw`/`cW`. Does not take a w/W motion: change-word is sticky
+/// end-of-word (like ce/cE for the first unit), not exclusive next-word-start.
 pub fn viChangeWordMotionRange(
     bytes: []const u8,
     cursor_byte: usize,
     motion_command: u21,
     count: usize,
-    motion: ViMotionResult,
 ) ViMotionRange {
-    // `motion` is the w/W landing point from the operator path. Change-word does
-    // not use that exclusive next-word-start range; classic vi treats cw/cW on a
-    // non-blank like change-to-end-of-word so following whitespace is preserved.
-    // Unlike plain `e`, the first unit stays on the current word when the cursor
-    // is already on its last character (so `cw` on a single-letter word does not
-    // swallow the blank and next word).
-    _ = motion;
     if (bytes.len == 0) return .{ .start = 0, .end = 0, .cursor_after_delete = 0 };
     // On a blank with count 1, only change the whitespace under the cursor so a
     // following run of blanks is not collapsed.
@@ -471,22 +466,7 @@ pub fn currentViWordEnd(bytes: []const u8, cursor_byte: usize, kind: ViWordKind)
         while (cursor < bytes.len and isAsciiWhitespace(bytes[cursor])) cursor = nextCodepointEnd(bytes, cursor);
         if (cursor >= bytes.len) return lastGraphemeStart(bytes);
     }
-    if (kind == .bigword) {
-        while (nextCodepointEnd(bytes, cursor) < bytes.len and
-            !isAsciiWhitespace(bytes[nextCodepointEnd(bytes, cursor)]))
-        {
-            cursor = nextCodepointEnd(bytes, cursor);
-        }
-    } else {
-        const class = viWordClass(bytes[cursor]);
-        while (nextCodepointEnd(bytes, cursor) < bytes.len and
-            !isAsciiWhitespace(bytes[nextCodepointEnd(bytes, cursor)]) and
-            viWordClass(bytes[nextCodepointEnd(bytes, cursor)]) == class)
-        {
-            cursor = nextCodepointEnd(bytes, cursor);
-        }
-    }
-    return cursor;
+    return scanToWordEnd(bytes, cursor, kind);
 }
 
 pub fn changeViWordEndCount(bytes: []const u8, cursor_byte: usize, count: usize, kind: ViWordKind) usize {
@@ -577,6 +557,12 @@ pub fn nextViWordEnd(bytes: []const u8, cursor_byte: usize, kind: ViWordKind) us
         while (cursor < bytes.len and isAsciiWhitespace(bytes[cursor])) cursor = nextCodepointEnd(bytes, cursor);
     }
     if (cursor >= bytes.len) return lastGraphemeStart(bytes);
+    return scanToWordEnd(bytes, cursor, kind);
+}
+
+/// Advance from a non-blank `cursor` to the last codepoint of its word/bigword.
+fn scanToWordEnd(bytes: []const u8, cursor_byte: usize, kind: ViWordKind) usize {
+    var cursor = cursor_byte;
     if (kind == .bigword) {
         while (nextCodepointEnd(bytes, cursor) < bytes.len and
             !isAsciiWhitespace(bytes[nextCodepointEnd(bytes, cursor)]))
@@ -714,4 +700,45 @@ pub fn isAsciiWhitespace(byte: u8) bool {
         ' ', '\t', '\n', '\r' => true,
         else => false,
     };
+}
+
+test "currentViWordEnd is sticky on last character of word" {
+    try std.testing.expectEqual(@as(usize, 0), currentViWordEnd("a b", 0, .word));
+    try std.testing.expectEqual(@as(usize, 2), currentViWordEnd("a b", 2, .word));
+    try std.testing.expectEqual(@as(usize, 4), currentViWordEnd("hello", 4, .word));
+    try std.testing.expectEqual(@as(usize, 4), currentViWordEnd("hello", 0, .word));
+    // Word class splits alnum and punctuation: "foo" then "." then "bar".
+    try std.testing.expectEqual(@as(usize, 2), currentViWordEnd("foo.bar", 0, .word));
+    try std.testing.expectEqual(@as(usize, 3), currentViWordEnd("foo.bar", 3, .word));
+    try std.testing.expectEqual(@as(usize, 6), currentViWordEnd("foo.bar", 4, .word));
+}
+
+test "changeViWordEndCount spans additional words for counts above one" {
+    try std.testing.expectEqual(@as(usize, 2), changeViWordEndCount("one two", 0, 1, .word));
+    try std.testing.expectEqual(@as(usize, 6), changeViWordEndCount("one two", 0, 2, .word));
+    // First unit sticky on 'a', second unit is end of 'b' (index 2).
+    try std.testing.expectEqual(@as(usize, 2), changeViWordEndCount("a b c", 0, 2, .word));
+    try std.testing.expectEqual(@as(usize, 4), changeViWordEndCount("a b c", 0, 3, .word));
+}
+
+test "viChangeWordMotionRange preserves blanks around the changed word" {
+    const mid = viChangeWordMotionRange("one two three", 0, 'w', 1);
+    try std.testing.expectEqual(@as(usize, 0), mid.start);
+    try std.testing.expectEqual(@as(usize, 3), mid.end);
+
+    const short_last = viChangeWordMotionRange("a b", 0, 'w', 1);
+    try std.testing.expectEqual(@as(usize, 0), short_last.start);
+    try std.testing.expectEqual(@as(usize, 1), short_last.end);
+
+    const final_word = viChangeWordMotionRange("hello world", 6, 'w', 1);
+    try std.testing.expectEqual(@as(usize, 6), final_word.start);
+    try std.testing.expectEqual(@as(usize, 11), final_word.end);
+
+    const on_blank = viChangeWordMotionRange("one  two", 3, 'w', 1);
+    try std.testing.expectEqual(@as(usize, 3), on_blank.start);
+    try std.testing.expectEqual(@as(usize, 4), on_blank.end);
+
+    const two_words = viChangeWordMotionRange("one two three", 0, 'w', 2);
+    try std.testing.expectEqual(@as(usize, 0), two_words.start);
+    try std.testing.expectEqual(@as(usize, 7), two_words.end);
 }

--- a/src/editor/vi.zig
+++ b/src/editor/vi.zig
@@ -439,7 +439,16 @@ pub fn viChangeWordMotionRange(
     count: usize,
     motion: ViMotionResult,
 ) ViMotionRange {
-    if (bytes.len == 0 or motion.cursor <= cursor_byte) return viMotionRange(bytes, cursor_byte, motion);
+    // `motion` is the w/W landing point from the operator path. Change-word does
+    // not use that exclusive next-word-start range; classic vi treats cw/cW on a
+    // non-blank like change-to-end-of-word so following whitespace is preserved.
+    // Unlike plain `e`, the first unit stays on the current word when the cursor
+    // is already on its last character (so `cw` on a single-letter word does not
+    // swallow the blank and next word).
+    _ = motion;
+    if (bytes.len == 0) return .{ .start = 0, .end = 0, .cursor_after_delete = 0 };
+    // On a blank with count 1, only change the whitespace under the cursor so a
+    // following run of blanks is not collapsed.
     if (count == 1 and cursor_byte < bytes.len and isAsciiWhitespace(bytes[cursor_byte])) {
         return .{
             .start = cursor_byte,
@@ -447,18 +456,44 @@ pub fn viChangeWordMotionRange(
             .cursor_after_delete = cursor_byte,
         };
     }
-    if (motion.cursor == lastGraphemeStart(bytes)) {
-        return .{ .start = cursor_byte, .end = bytes.len, .cursor_after_delete = cursor_byte };
-    }
+    const kind: ViWordKind = if (motion_command == 'W') .bigword else .word;
+    const end_cursor = changeViWordEndCount(bytes, cursor_byte, count, kind);
+    return viMotionRange(bytes, cursor_byte, .{ .cursor = end_cursor, .inclusive = true });
+}
 
-    var end = motion.cursor;
-    while (end > cursor_byte) {
-        const previous = previousCodepointStart(bytes, end);
-        if (!isAsciiWhitespace(bytes[previous])) break;
-        end = previous;
+/// End of the word under/after `cursor_byte` without advancing when already on
+/// the word's last character (the first unit of cw/cW).
+pub fn currentViWordEnd(bytes: []const u8, cursor_byte: usize, kind: ViWordKind) usize {
+    if (bytes.len == 0) return 0;
+    if (cursor_byte >= lastGraphemeStart(bytes)) return lastGraphemeStart(bytes);
+    var cursor = cursor_byte;
+    if (cursor < bytes.len and isAsciiWhitespace(bytes[cursor])) {
+        while (cursor < bytes.len and isAsciiWhitespace(bytes[cursor])) cursor = nextCodepointEnd(bytes, cursor);
+        if (cursor >= bytes.len) return lastGraphemeStart(bytes);
     }
-    if (end == cursor_byte and (motion_command == 'w' or motion_command == 'W')) end = motion.cursor;
-    return .{ .start = cursor_byte, .end = end, .cursor_after_delete = cursor_byte };
+    if (kind == .bigword) {
+        while (nextCodepointEnd(bytes, cursor) < bytes.len and
+            !isAsciiWhitespace(bytes[nextCodepointEnd(bytes, cursor)]))
+        {
+            cursor = nextCodepointEnd(bytes, cursor);
+        }
+    } else {
+        const class = viWordClass(bytes[cursor]);
+        while (nextCodepointEnd(bytes, cursor) < bytes.len and
+            !isAsciiWhitespace(bytes[nextCodepointEnd(bytes, cursor)]) and
+            viWordClass(bytes[nextCodepointEnd(bytes, cursor)]) == class)
+        {
+            cursor = nextCodepointEnd(bytes, cursor);
+        }
+    }
+    return cursor;
+}
+
+pub fn changeViWordEndCount(bytes: []const u8, cursor_byte: usize, count: usize, kind: ViWordKind) usize {
+    var cursor = currentViWordEnd(bytes, cursor_byte, kind);
+    var remaining = count - 1;
+    while (remaining != 0) : (remaining -= 1) cursor = nextViWordEnd(bytes, cursor, kind);
+    return cursor;
 }
 
 pub fn multiplyViCounts(a: usize, b: usize) usize {


### PR DESCRIPTION
This fixes two issues:
1. The command `cw` would eat any leading spaces and `cw` could also eat a character if the last word was a single character.
    ```sh
    # using CAPS/underscore for cursor position
    
    ## Before
    git merge Main
    # cw
    git merge_
    
    ## After
    git merge Main
    # cw
    git merge _
    ```
    ```sh
    ## Before
    Git c
    # cw
    # (blank)
    
    ## After
    Git c
    # cw
    _ c
    ```
2. (More of a behavioral change to be at parity with vi mode in bash/zsh) Switching to insert mode via `i` or `a` would insert the cursor one position to the right from bash/zsh vi modes.

The fix for 1. introduced a wrapper `viDeleteRangeForState` to allow explicitly stating the subsequent vi mode to be in.

Amp thread: https://ampcode.com/threads/T-019f68be-46a5-7398-87d3-a239915c0bc8