### PR TITLE
Fix job control hang

### DIFF
--- a/src/host/RealHost.zig
+++ b/src/host/RealHost.zig
@@ -309,6 +309,15 @@ pub fn terminalProcessGroup(_: RealHost, fd: host.Fd) TerminalProcessGroupError!
 }
 
 pub fn setTerminalProcessGroup(_: RealHost, fd: host.Fd, process_group: host.Pid) TerminalProcessGroupError!void {
+    // Block SIGTTOU while claiming the terminal. Otherwise a shell that is not
+    // currently the foreground process group can be stopped mid-handoff when
+    // tcsetpgrp generates TTOU, leaving fg/bg and child jobs wedged.
+    var blocked = std.posix.sigemptyset();
+    std.posix.sigaddset(&blocked, .TTOU);
+    var previous: std.posix.sigset_t = undefined;
+    std.posix.sigprocmask(std.posix.SIG.BLOCK, &blocked, &previous);
+    defer std.posix.sigprocmask(std.posix.SIG.SETMASK, &previous, null);
+
     while (true) {
         const rc = tcsetpgrp(fd.raw(), @intCast(process_group));
         switch (std.c.errno(rc)) {

--- a/src/interactive.zig
+++ b/src/interactive.zig
@@ -144,6 +144,11 @@ fn ignoreInteractiveJobControlSignals(sh: *RushShell) void {
     }
 }
 
+fn deinitTerminalAfterRestore(session: anytype, terminal: anytype) void {
+    session.restoreTerminalProcessGroup();
+    terminal.deinit();
+}
+
 const InteractiveSession = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -168,8 +173,7 @@ const InteractiveSession = struct {
         };
         defer self.clearHistoryCurrentDirectory();
         defer self.command_cache.deinit(self.allocator);
-        defer self.restoreTerminalProcessGroup();
-        defer terminal.deinit();
+        defer deinitTerminalAfterRestore(self, &terminal);
         self.terminal = &terminal;
         defer self.terminal = null;
         self.sh.setDirectoryChangeCallback(self, onDirectoryChange);
@@ -1518,6 +1522,38 @@ test "interactive input analysis styles reserved words operators options and exp
         try std.testing.expectEqual(want.severity, span.severity);
         try std.testing.expectEqualStrings(want.text, text[span.start..span.end]);
     }
+}
+
+test "interactive terminal teardown restores process group before closing tty" {
+    const Event = enum { restore, deinit };
+    const FakeSession = struct {
+        tty_closed: bool = false,
+        events: std.ArrayList(Event) = .empty,
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        fn restoreTerminalProcessGroup(self: *@This()) void {
+            std.testing.expect(!self.tty_closed) catch unreachable;
+            self.events.append(std.testing.allocator, .restore) catch unreachable;
+        }
+    };
+    const FakeTerminal = struct {
+        session: *FakeSession,
+
+        // ziglint-ignore: Z020 Z030 test-local helper uses @This(); avoid non-semantic refactor
+        fn deinit(self: *@This()) void {
+            self.session.tty_closed = true;
+            self.session.events.append(std.testing.allocator, .deinit) catch unreachable;
+        }
+    };
+
+    var session: FakeSession = .{};
+    defer session.events.deinit(std.testing.allocator);
+    var terminal: FakeTerminal = .{ .session = &session };
+
+    deinitTerminalAfterRestore(&session, &terminal);
+
+    try std.testing.expect(session.tty_closed);
+    try std.testing.expectEqualSlices(Event, &.{ .restore, .deinit }, session.events.items);
 }
 
 test {

--- a/src/interactive.zig
+++ b/src/interactive.zig
@@ -97,13 +97,18 @@ fn enableJobControl(sh: *RushShell, tty_fd: host.Fd) ?host.Pid {
     sh.state.shell_pid = shell_pid;
     sh.state.controlling_tty = null;
     ignoreInteractiveJobControlSignals(sh);
-    sh.host.setProcessGroup(0, shell_pid) catch {
-        sh.state.options.monitor = false;
-        return null;
-    };
+    // Login shells are usually already process-group leaders (and often session
+    // leaders). setpgid fails with EPERM for session leaders, so only create a
+    // new group when we are not already the intended leader.
+    if (original_process_group != shell_pid) {
+        sh.host.setProcessGroup(0, shell_pid) catch {
+            sh.state.options.monitor = false;
+            return null;
+        };
+    }
     sh.host.setTerminalProcessGroup(tty_fd, shell_pid) catch {
         // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
-        sh.host.setProcessGroup(0, original_process_group) catch {};
+        if (original_process_group != shell_pid) sh.host.setProcessGroup(0, original_process_group) catch {};
         sh.state.options.monitor = false;
         return null;
     };
@@ -111,7 +116,7 @@ fn enableJobControl(sh: *RushShell, tty_fd: host.Fd) ?host.Pid {
         // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
         sh.host.setTerminalProcessGroup(tty_fd, original_terminal_group) catch {};
         // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
-        sh.host.setProcessGroup(0, original_process_group) catch {};
+        if (original_process_group != shell_pid) sh.host.setProcessGroup(0, original_process_group) catch {};
         sh.state.options.monitor = false;
         return null;
     };
@@ -119,7 +124,7 @@ fn enableJobControl(sh: *RushShell, tty_fd: host.Fd) ?host.Pid {
         // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
         sh.host.setTerminalProcessGroup(tty_fd, original_terminal_group) catch {};
         // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
-        sh.host.setProcessGroup(0, original_process_group) catch {};
+        if (original_process_group != shell_pid) sh.host.setProcessGroup(0, original_process_group) catch {};
         sh.state.options.monitor = false;
         return null;
     }

--- a/src/interactive.zig
+++ b/src/interactive.zig
@@ -95,6 +95,7 @@ fn enableJobControl(sh: *RushShell, tty_fd: host.Fd) ?host.Pid {
 
     const shell_pid = sh.host.currentProcessId();
     sh.state.shell_pid = shell_pid;
+    sh.state.controlling_tty = null;
     ignoreInteractiveJobControlSignals(sh);
     sh.host.setProcessGroup(0, shell_pid) catch {
         sh.state.options.monitor = false;
@@ -122,6 +123,9 @@ fn enableJobControl(sh: *RushShell, tty_fd: host.Fd) ?host.Pid {
         sh.state.options.monitor = false;
         return null;
     }
+    // Use the same tty for later give/restore so fg does not hand off via a
+    // redirected stdin while the interactive session owns /dev/tty.
+    sh.state.controlling_tty = tty_fd;
     sh.state.options.monitor = true;
     return original_terminal_group;
 }
@@ -194,8 +198,9 @@ const InteractiveSession = struct {
 
     fn restoreTerminalProcessGroup(self: *InteractiveSession) void {
         if (self.restore_terminal_pgrp) |process_group| {
+            const tty_fd = self.sh.state.controlling_tty orelse .stdin;
             // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
-            self.sh.host.setTerminalProcessGroup(.stdin, process_group) catch {};
+            self.sh.host.setTerminalProcessGroup(tty_fd, process_group) catch {};
         }
     }
 

--- a/src/shell/builtin.zig
+++ b/src/shell/builtin.zig
@@ -790,11 +790,12 @@ fn giveTerminalToJob(shell: anytype, process_group: host.Pid) !?host.Pid {
     };
     if (!@hasDecl(HostType, "terminalProcessGroup") or
         !@hasDecl(HostType, "setTerminalProcessGroup")) return null;
-    const shell_process_group = shell.host.terminalProcessGroup(.stdin) catch |err| switch (err) {
+    const tty_fd = shell.state.controlling_tty orelse .stdin;
+    const shell_process_group = shell.host.terminalProcessGroup(tty_fd) catch |err| switch (err) {
         error.NotATerminal => return null,
         else => return err,
     };
-    shell.host.setTerminalProcessGroup(.stdin, process_group) catch |err| switch (err) {
+    shell.host.setTerminalProcessGroup(tty_fd, process_group) catch |err| switch (err) {
         error.NotATerminal => return null,
         else => return err,
     };
@@ -808,7 +809,7 @@ fn restoreTerminalToShell(shell: anytype, process_group: host.Pid) void {
     };
     if (!@hasDecl(HostType, "setTerminalProcessGroup")) return;
     // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
-    shell.host.setTerminalProcessGroup(.stdin, process_group) catch {};
+    shell.host.setTerminalProcessGroup(shell.state.controlling_tty orelse .stdin, process_group) catch {};
 }
 
 fn sendContinueToJob(shell: anytype, job: state_mod.BackgroundJob) !void {

--- a/src/shell/builtin.zig
+++ b/src/shell/builtin.zig
@@ -2200,6 +2200,7 @@ const SetOption = enum {
     emacs,
     errexit,
     hashall,
+    monitor,
     noclobber,
     noexec,
     noglob,
@@ -2216,6 +2217,7 @@ const set_option_names = std.StaticStringMap(SetOption).initComptime(.{
     .{ "emacs", .emacs },
     .{ "errexit", .errexit },
     .{ "hashall", .hashall },
+    .{ "monitor", .monitor },
     .{ "noclobber", .noclobber },
     .{ "noexec", .noexec },
     .{ "noglob", .noglob },
@@ -2232,6 +2234,7 @@ const set_option_order = [_]SetOption{
     .emacs,
     .errexit,
     .hashall,
+    .monitor,
     .noclobber,
     .noexec,
     .noglob,
@@ -2249,6 +2252,7 @@ fn setOptionName(option: SetOption) []const u8 {
         .emacs => "emacs",
         .errexit => "errexit",
         .hashall => "hashall",
+        .monitor => "monitor",
         .noclobber => "noclobber",
         .noexec => "noexec",
         .noglob => "noglob",
@@ -2267,6 +2271,7 @@ fn setOptionEnabled(shell: anytype, option: SetOption) bool {
         .emacs => shell.state.options.emacs,
         .errexit => shell.state.options.errexit,
         .hashall => shell.state.options.hashall,
+        .monitor => shell.state.options.monitor,
         .noclobber => shell.state.options.noclobber,
         .noexec => shell.state.options.noexec,
         .noglob => shell.state.options.noglob,
@@ -2283,19 +2288,20 @@ fn listSetOptions(shell: anytype, table: bool) !result.EvalResult {
     for (set_option_order) |option| {
         const name = setOptionName(option);
         const enabled = setOptionEnabled(shell, option);
-        if (table) {
-            try shell.host.writeAll(.stdout, try std.fmt.allocPrint(
+        const text = if (table)
+            try std.fmt.allocPrint(
                 shell.scratchAllocator(),
                 "{s}\t{s}\n",
                 .{ name, if (enabled) "on" else "off" },
-            ));
-        } else {
-            try shell.host.writeAll(.stdout, try std.fmt.allocPrint(
+            )
+        else
+            try std.fmt.allocPrint(
                 shell.scratchAllocator(),
                 "set {s}o {s}\n",
                 .{ if (enabled) "-" else "+", name },
-            ));
-        }
+            );
+        defer shell.scratchAllocator().free(text);
+        try shell.host.writeAll(.stdout, text);
     }
     return .{};
 }
@@ -2313,6 +2319,7 @@ fn setNamedOption(shell: anytype, name: []const u8, enabled: bool) bool {
         },
         .errexit => shell.state.options.errexit = enabled,
         .hashall => shell.state.options.hashall = enabled,
+        .monitor => shell.state.options.monitor = enabled,
         .noclobber => shell.state.options.noclobber = enabled,
         .noexec => shell.state.options.noexec = enabled,
         .noglob => shell.state.options.noglob = enabled,
@@ -3129,6 +3136,85 @@ test "set -o notify toggles notify option" {
         (try eval(&shell, set_definition, &.{ "set", "+o", "notify" })).status,
     );
     try std.testing.expect(!shell.state.options.notify);
+}
+
+test "set -o monitor toggles and lists the monitor option" {
+    const TestHost = struct {
+        stdout: std.ArrayList(u8) = .empty,
+
+        // ziglint-ignore: Z020 Z030 test helper/reusable deinit; preserve behavior
+        fn deinit(self: *@This()) void {
+            self.stdout.deinit(std.testing.allocator);
+        }
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn writeAll(self: *@This(), fd: host.Fd, bytes: []const u8) !void {
+            switch (fd) {
+                .stdout => try self.stdout.appendSlice(std.testing.allocator, bytes),
+                else => {},
+            }
+        }
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn setFileCreationMask(_: *@This(), mask: u32) u32 {
+            return mask;
+        }
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn currentProcessId(_: *@This()) host.Pid {
+            return 1;
+        }
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn sendSignal(_: *@This(), _: host.Pid, _: u8) !void {}
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn setSignalDefault(_: *@This(), _: u8) !void {}
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn setSignalIgnored(_: *@This(), _: u8) !void {}
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        pub fn installSignalTrap(_: *@This(), _: u8) !void {}
+    };
+    const TestShell = struct {
+        host: TestHost = .{},
+        state: state_mod.State,
+
+        // ziglint-ignore: Z020 test-local helper uses @This(); avoid non-semantic refactor
+        fn scratchAllocator(_: *@This()) std.mem.Allocator {
+            return std.testing.allocator;
+        }
+    };
+
+    var shell: TestShell = .{ .state = state_mod.State.init(std.testing.allocator, .{}) };
+    defer shell.state.deinit();
+    defer shell.host.deinit();
+    const set_definition = lookup("set").?;
+
+    try std.testing.expect(!shell.state.options.monitor);
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "-o", "monitor" })).status,
+    );
+    try std.testing.expect(shell.state.options.monitor);
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "-o" })).status,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, shell.host.stdout.items, "monitor\ton\n") != null);
+
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "+o", "monitor" })).status,
+    );
+    try std.testing.expect(!shell.state.options.monitor);
+    shell.host.stdout.clearRetainingCapacity();
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try eval(&shell, set_definition, &.{ "set", "-o" })).status,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, shell.host.stdout.items, "monitor\toff\n") != null);
 }
 
 test "set -o vi and emacs are mutually exclusive editing options" {

--- a/src/shell/eval.zig
+++ b/src/shell/eval.zig
@@ -348,11 +348,12 @@ fn giveTerminalToProcessGroup(shell: anytype, process_group: host_mod.Pid) !?hos
     };
     if (!@hasDecl(HostType, "terminalProcessGroup") or
         !@hasDecl(HostType, "setTerminalProcessGroup")) return null;
-    const shell_process_group = shell.host.terminalProcessGroup(.stdin) catch |err| switch (err) {
+    const tty_fd = shell.state.controlling_tty orelse .stdin;
+    const shell_process_group = shell.host.terminalProcessGroup(tty_fd) catch |err| switch (err) {
         error.NotATerminal => return null,
         else => return err,
     };
-    shell.host.setTerminalProcessGroup(.stdin, process_group) catch |err| switch (err) {
+    shell.host.setTerminalProcessGroup(tty_fd, process_group) catch |err| switch (err) {
         error.NotATerminal => return null,
         else => return err,
     };
@@ -366,7 +367,7 @@ fn restoreTerminalToProcessGroup(shell: anytype, process_group: host_mod.Pid) vo
     };
     if (!@hasDecl(HostType, "setTerminalProcessGroup")) return;
     // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
-    shell.host.setTerminalProcessGroup(.stdin, process_group) catch {};
+    shell.host.setTerminalProcessGroup(shell.state.controlling_tty orelse .stdin, process_group) catch {};
 }
 
 fn pipelineStatus(statuses: []const host_mod.WaitStatus, pipefail: bool) result.ExitStatus {

--- a/src/shell/state.zig
+++ b/src/shell/state.zig
@@ -306,6 +306,9 @@ pub const State = struct {
     running_exit_trap: bool = false,
     running_signal_trap: bool = false,
     shell_pid: ?host.Pid = null,
+    /// Controlling terminal used for job-control handoff. Prefer this over
+    /// stdin so fg/bg still work when the interactive editor owns /dev/tty.
+    controlling_tty: ?host.Fd = null,
     parent_pid: ?host.Pid = null,
     start_time_ns: i128 = 0,
     seconds_base_time_ns: i128 = 0,


### PR DESCRIPTION
Three fixes:
1. Resuming a suspended nvim process would cause the shell to hang.
    > Hardened terminal handoff for fg / foreground jobs:
    >
    > - Block SIGTTOU around tcsetpgrp in RealHost.setTerminalProcessGroup
    > Avoids the shell getting stopped mid-handoff.
    > - Remember the controlling tty (state.controlling_tty = interactive /dev/tty) when job control is enabled.
    > - Use that fd for give/restore in fg, foreground external commands, pipelines, and session teardown — not hard-coded stdin.
3. Job monitor mode would not be set if rush was used as the login shell.
    > - Skip setpgid when the shell is already its process-group leader (pgid == pid)
    > - Login/chsh session leaders no longer fail enableJobControl with EPERM
    > - Nested shells still create a new group when needed 
5. `monitor` was mising from `set -o` output.
    > - Add monitor to set -o / set +o named options and listing
    > - Free temporary list allocations (fixes test leaks)
    > - Unit test for toggle + set -o table output 

Amp thread (quite lengthy because I was learning a bit in this, started on the wrong foot): https://ampcode.com/threads/T-019f6e2e-cb77-752f-9b6c-170387f6ffd4