### PR TITLE
tests: avoid PATH collision in unalias grammar case

### DIFF
--- a/tests/posix/shell_grammar.zon
+++ b/tests/posix/shell_grammar.zon
@@ -560,9 +560,9 @@
         .{
             .name = "unalias takes effect for later complete commands",
             .script =
-            \\alias greet='printf aliased\n'
-            \\unalias greet
-            \\greet
+            \\alias no_such_posix_command_for_rush='printf aliased\n'
+            \\unalias no_such_posix_command_for_rush
+            \\no_such_posix_command_for_rush
             ,
             .stdout = "",
             .stderr_match = .nonempty,


### PR DESCRIPTION
There is some haskell package that's a dep of pandoc-cli with a `greet` binary that caused a false flag on my system, this makes the test's dummy command a lot more obsure :joy: 

Amp-Thread-ID: https://ampcode.com/threads/T-019f91f2-b883-70ad-9978-01e9006cc7f1