### PR TITLE
Handle filenames with spaces for tab completion

### DIFF
--- a/src/completion.zig
+++ b/src/completion.zig
@@ -34,28 +34,49 @@ pub fn complete(
 
     if (analyzed.kind == .parameter) {
         try appendVariableCandidates(allocator, &builder, sh, analyzed.replace_start, analyzed.replace_end);
-        return applyBuiltCandidates(allocator, source, &builder);
+        return applyBuiltCandidates(allocator, source, &builder, analyzed);
     }
 
     if (analyzed.kind == .command) {
-        if (std.mem.indexOfScalar(u8, analyzed.prefix, '/') == null) {
+        const command_prefix = if (analyzed.literal_prefix) |literal| literal.value else analyzed.prefix;
+        if (std.mem.indexOfScalar(u8, command_prefix, '/') == null) {
             try appendCommandCandidates(allocator, &builder, sh, analyzed.replace_start, analyzed.replace_end);
-            return applyBuiltCandidates(allocator, source, &builder);
+            return applyBuiltCandidates(allocator, source, &builder, analyzed);
         }
-        // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
-        try appendPathCandidates(allocator, &builder, sh, analyzed.prefix, analyzed.replace_start, analyzed.replace_end, false);
-        return applyBuiltCandidates(allocator, source, &builder);
+        if (analyzed.literal_prefix) |literal| {
+            try appendPathCandidates(
+                allocator,
+                &builder,
+                sh,
+                literal.value,
+                literal.expands_leading_tilde,
+                analyzed.replace_start,
+                analyzed.replace_end,
+                false,
+            );
+        }
+        return applyBuiltCandidates(allocator, source, &builder, analyzed);
     }
 
     if (analyzed.root) |root| {
         if (try completeFromManifest(allocator, io, sh, &builder, analyzed, root)) |handled| {
-            if (handled) return applyBuiltCandidates(allocator, source, &builder);
+            if (handled) return applyBuiltCandidates(allocator, source, &builder, analyzed);
         }
     }
 
-    // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
-    try appendPathCandidates(allocator, &builder, sh, analyzed.prefix, analyzed.replace_start, analyzed.replace_end, false);
-    return applyBuiltCandidates(allocator, source, &builder);
+    if (analyzed.literal_prefix) |literal| {
+        try appendPathCandidates(
+            allocator,
+            &builder,
+            sh,
+            literal.value,
+            literal.expands_leading_tilde,
+            analyzed.replace_start,
+            analyzed.replace_end,
+            false,
+        );
+    }
+    return applyBuiltCandidates(allocator, source, &builder, analyzed);
 }
 
 fn rushShellFromOpaque(context: *anyopaque) *shell.ShellWithBuiltins(host.RealHost, extensions.rush.registry) {
@@ -76,12 +97,19 @@ const AnalyzedLine = struct {
     replace_start: usize,
     replace_end: usize,
     prefix: []const u8,
+    /// Literal value of the typed word up to the cursor. Null when evaluation
+    /// would be required to determine it.
+    literal_prefix: ?shell.word_quoting.LiteralWord,
+    /// Literal value of the full current word, used for candidate matching.
+    literal_query: ?shell.word_quoting.LiteralWord,
     kind: CompletionKind,
     root: ?[]const u8,
     command_word_index: ?usize,
 
     fn deinit(self: AnalyzedLine, allocator: std.mem.Allocator) void {
         allocator.free(self.words);
+        if (self.literal_prefix) |literal| literal.deinit(allocator);
+        if (self.literal_query) |literal| literal.deinit(allocator);
     }
 };
 
@@ -146,8 +174,16 @@ fn analyzeLine(allocator: std.mem.Allocator, source: []const u8, raw_cursor: usi
     const replace_start = if (current_word_index) |index| words.items[index].start else cursor;
     const replace_end = if (current_word_index) |index| words.items[index].end else cursor;
     const raw_prefix = source[replace_start..cursor];
-    const parameter = raw_prefix.len != 0 and raw_prefix[0] == '$';
+    // Issue 8 dollar-single-quotes begin with `$'`, but are literal words rather
+    // than parameter expansions.
+    const parameter = raw_prefix.len != 0 and raw_prefix[0] == '$' and
+        (raw_prefix.len == 1 or raw_prefix[1] != '\'');
     const prefix = if (parameter) raw_prefix[1..] else raw_prefix;
+    const word_start = if (parameter) replace_start + 1 else replace_start;
+    const literal_prefix = try shell.word_quoting.parseLiteralWord(allocator, prefix);
+    errdefer if (literal_prefix) |literal| literal.deinit(allocator);
+    const literal_query = try shell.word_quoting.parseLiteralWord(allocator, source[word_start..replace_end]);
+    errdefer if (literal_query) |literal| literal.deinit(allocator);
 
     const is_command = if (current_word_class) |class|
         class == .command or class == .reserved
@@ -159,9 +195,11 @@ fn analyzeLine(allocator: std.mem.Allocator, source: []const u8, raw_cursor: usi
     return .{
         .words = try words.toOwnedSlice(allocator),
         .current_word_index = current_word_index,
-        .replace_start = if (parameter) replace_start + 1 else replace_start,
+        .replace_start = word_start,
         .replace_end = replace_end,
         .prefix = prefix,
+        .literal_prefix = literal_prefix,
+        .literal_query = literal_query,
         .kind = kind,
         .root = root,
         .command_word_index = command_word_index,
@@ -255,19 +293,66 @@ const Builder = struct {
     }
 };
 
-fn applyBuiltCandidates(allocator: std.mem.Allocator, source: []const u8, builder: *Builder) !Application {
+fn applyBuiltCandidates(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    builder: *Builder,
+    analyzed: AnalyzedLine,
+) !Application {
     const candidates = try builder.take(allocator);
     defer editor_completion.freeCandidates(allocator, candidates);
 
     var matches: std.ArrayList(editor_completion.Candidate) = .empty;
     defer matches.deinit(allocator);
-    for (candidates) |candidate| {
-        const query = source[candidate.replace_start..candidate.replace_end];
-        if (editor_completion.candidateMatchRank(candidate, query, .prefixOnly()) != null) {
-            try matches.append(allocator, candidate);
+    for (candidates) |*candidate| {
+        try preparePathCandidateInsert(allocator, candidate, analyzed);
+        const query = if (analyzed.literal_query) |literal|
+            if (candidateUsesLiteralQuery(candidate.*) and
+                candidate.replace_start == analyzed.replace_start and
+                candidate.replace_end == analyzed.replace_end)
+                literal.value
+            else
+                source[candidate.replace_start..candidate.replace_end]
+        else
+            source[candidate.replace_start..candidate.replace_end];
+        if (editor_completion.candidateMatchRank(candidate.*, query, .prefixOnly()) != null) {
+            try matches.append(allocator, candidate.*);
         }
     }
     return editor_completion.applyCandidates(allocator, matches.items);
+}
+
+fn candidateUsesLiteralQuery(candidate: editor_completion.Candidate) bool {
+    return candidate.kind == .file or candidate.kind == .directory or
+        (candidate.kind == .command and candidate.insert != null);
+}
+
+fn preparePathCandidateInsert(
+    allocator: std.mem.Allocator,
+    candidate: *editor_completion.Candidate,
+    analyzed: AnalyzedLine,
+) error{OutOfMemory}!void {
+    if (candidate.insert != null or (candidate.kind != .file and candidate.kind != .directory)) return;
+
+    const escaped_value: ?[]const u8 = if (analyzed.literal_prefix) |literal|
+        if (literal.open_quote) |style|
+            try shell.word_quoting.quote(allocator, candidate.value, style, .{
+                .close = candidate.kind != .directory or candidate.suffix != null,
+            })
+        else
+            try shell.word_quoting.escapeIfNeeded(allocator, candidate.value, .{
+                .preserve_leading_tilde = literal.expands_leading_tilde,
+            })
+    else
+        try shell.word_quoting.escapeIfNeeded(allocator, candidate.value, .{});
+    const owned_value = escaped_value orelse return;
+
+    if (candidate.suffix) |suffix| {
+        defer allocator.free(owned_value);
+        candidate.insert = try std.mem.concat(allocator, u8, &.{ owned_value, suffix });
+    } else {
+        candidate.insert = owned_value;
+    }
 }
 
 fn completeFromManifest(
@@ -536,10 +621,32 @@ fn appendProviderCandidates(
 
 // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
 fn appendBuiltinProvider(allocator: std.mem.Allocator, builder: *Builder, sh: anytype, analyzed: AnalyzedLine, name: []const u8) !void {
-    // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
-    if (std.mem.eql(u8, name, "files")) return appendPathCandidates(allocator, builder, sh, analyzed.prefix, analyzed.replace_start, analyzed.replace_end, false);
-    // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
-    if (std.mem.eql(u8, name, "directories")) return appendPathCandidates(allocator, builder, sh, analyzed.prefix, analyzed.replace_start, analyzed.replace_end, true);
+    if (std.mem.eql(u8, name, "files")) {
+        const literal = analyzed.literal_prefix orelse return;
+        return appendPathCandidates(
+            allocator,
+            builder,
+            sh,
+            literal.value,
+            literal.expands_leading_tilde,
+            analyzed.replace_start,
+            analyzed.replace_end,
+            false,
+        );
+    }
+    if (std.mem.eql(u8, name, "directories")) {
+        const literal = analyzed.literal_prefix orelse return;
+        return appendPathCandidates(
+            allocator,
+            builder,
+            sh,
+            literal.value,
+            literal.expands_leading_tilde,
+            analyzed.replace_start,
+            analyzed.replace_end,
+            true,
+        );
+    }
     // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
     if (std.mem.eql(u8, name, "executables")) return appendPathExecutableCandidates(allocator, builder, sh, analyzed.replace_start, analyzed.replace_end);
     // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
@@ -596,9 +703,11 @@ fn appendFunctionProvider(
     defer allocator.free(parsed_options);
     const operands = try operandsForProvider(allocator, analyzed, root_command);
     defer allocator.free(operands);
+    const provider_prefix = if (analyzed.literal_prefix) |literal| literal.value else analyzed.prefix;
     var provider_context = extensions.rush.CompletionContext.init(
         allocator,
-        analyzed.prefix,
+        provider_prefix,
+        if (analyzed.literal_prefix) |literal| literal.expands_leading_tilde else false,
         analyzed.replace_start,
         analyzed.replace_end,
         semantic.operand_index,
@@ -619,7 +728,7 @@ fn appendFunctionProvider(
     sh.state.removeVariable("rush_completion_argument_index");
     sh.state.removeVariable("rush_completion_options_terminated");
     sh.state.removeVariable("rush_completion_value_position");
-    try sh.state.putVariable(.{ .name = "rush_completion_prefix", .value = analyzed.prefix });
+    try sh.state.putVariable(.{ .name = "rush_completion_prefix", .value = provider_prefix });
     try sh.state.putVariable(.{ .name = "rush_completion_argument_index", .value = argument_index });
     // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
     try sh.state.putVariable(.{ .name = "rush_completion_options_terminated", .value = if (semantic.options_terminated) "true" else "false" });
@@ -963,25 +1072,35 @@ fn appendPathExecutableCandidates(allocator: std.mem.Allocator, builder: *Builde
             const full_path_z = try allocator.dupeZ(u8, full_path);
             defer allocator.free(full_path_z);
             if (!sh.host.fileAccessZ(full_path_z, .execute)) continue;
+            const insert = try shell.word_quoting.escapeIfNeeded(allocator, entry.name, .{});
+            defer if (insert) |owned| allocator.free(owned);
             // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
-            try builder.append(allocator, .{ .value = entry.name, .kind = .command, .replace_start = replace_start, .replace_end = replace_end });
+            try builder.append(allocator, .{ .value = entry.name, .insert = insert, .kind = .command, .replace_start = replace_start, .replace_end = replace_end });
         }
     }
 }
 
 // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
-fn appendPathCandidates(allocator: std.mem.Allocator, builder: *Builder, sh: anytype, prefix: []const u8, replace_start: usize, replace_end: usize, directories_only: bool) !void {
+fn appendPathCandidates(
+    allocator: std.mem.Allocator,
+    builder: *Builder,
+    sh: anytype,
+    prefix: []const u8,
+    expand_leading_tilde: bool,
+    replace_start: usize,
+    replace_end: usize,
+    directories_only: bool,
+) !void {
     // ziglint-ignore: Z011 deprecated API left unchanged to avoid semantic drift in lint-only pass
     const slash = std.mem.lastIndexOfScalar(u8, prefix, '/');
     const dir_prefix = if (slash) |index| prefix[0 .. index + 1] else "";
     const entry_prefix = if (slash) |index| prefix[index + 1 ..] else prefix;
     // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
     const unexpanded_dir_path = if (dir_prefix.len == 0) "." else if (std.mem.eql(u8, dir_prefix, "/")) "/" else std.mem.trimEnd(u8, dir_prefix, "/");
-    const dir_path = try completion_path.expandLeadingTilde(
-        allocator,
-        unexpanded_dir_path,
-        shellValue(sh, "HOME"),
-    );
+    const dir_path = if (expand_leading_tilde)
+        try completion_path.expandLeadingTilde(allocator, unexpanded_dir_path, shellValue(sh, "HOME"))
+    else
+        try allocator.dupe(u8, unexpanded_dir_path);
     defer allocator.free(dir_path);
     var entries = sh.host.listDir(allocator, dir_path) catch return;
     defer entries.deinit();
@@ -989,7 +1108,7 @@ fn appendPathCandidates(allocator: std.mem.Allocator, builder: *Builder, sh: any
     for (entries.entries) |entry| {
         if (entry.name.len == 0 or std.mem.eql(u8, entry.name, ".") or std.mem.eql(u8, entry.name, "..")) continue;
         if (!include_hidden and entry.name[0] == '.') continue;
-        const is_directory = try pathCandidateIsDirectory(allocator, sh, dir_prefix, entry);
+        const is_directory = try pathCandidateIsDirectory(allocator, sh, dir_prefix, expand_leading_tilde, entry);
         if (directories_only and !is_directory) continue;
         const value = if (is_directory)
             try std.fmt.allocPrint(allocator, "{s}{s}/", .{ dir_prefix, entry.name })
@@ -1005,6 +1124,7 @@ fn pathCandidateIsDirectory(
     allocator: std.mem.Allocator,
     sh: anytype,
     dir_prefix: []const u8,
+    expand_leading_tilde: bool,
     entry: host.DirectoryEntry,
 ) !bool {
     if (entry.kind == .directory) return true;
@@ -1012,11 +1132,10 @@ fn pathCandidateIsDirectory(
 
     const unexpanded_path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ dir_prefix, entry.name });
     defer allocator.free(unexpanded_path);
-    const path = try completion_path.expandLeadingTilde(
-        allocator,
-        unexpanded_path,
-        shellValue(sh, "HOME"),
-    );
+    const path = if (expand_leading_tilde)
+        try completion_path.expandLeadingTilde(allocator, unexpanded_path, shellValue(sh, "HOME"))
+    else
+        try allocator.dupe(u8, unexpanded_path);
     defer allocator.free(path);
     const path_z = try allocator.dupeZ(u8, path);
     defer allocator.free(path_z);
@@ -1449,6 +1568,10 @@ test "path completion follows symlinked directories before appending space" {
         env: []const [*:0]const u8 = &.{},
     };
 
+    const source = "nvim .config/ru";
+    const analyzed = try analyzeLine(std.testing.allocator, source, source.len);
+    defer analyzed.deinit(std.testing.allocator);
+    const literal = analyzed.literal_prefix orelse return error.ExpectedLiteralPath;
     var sh: TestShell = .{ .host = .{}, .state = .{} };
     var builder: Builder = .{};
     defer builder.deinit(std.testing.allocator);
@@ -1457,12 +1580,13 @@ test "path completion follows symlinked directories before appending space" {
         std.testing.allocator,
         &builder,
         &sh,
-        ".config/ru",
-        "nvim ".len,
-        "nvim .config/ru".len,
+        literal.value,
+        literal.expands_leading_tilde,
+        analyzed.replace_start,
+        analyzed.replace_end,
         false,
     );
-    var application = try applyBuiltCandidates(std.testing.allocator, "nvim .config/ru", &builder);
+    var application = try applyBuiltCandidates(std.testing.allocator, source, &builder, analyzed);
     defer application.deinit(std.testing.allocator);
 
     const edit = switch (application) {
@@ -1504,6 +1628,9 @@ test "path completion expands tilde for lookup and preserves it in candidates" {
     };
 
     const source = "nvim ~/.config/ru";
+    const analyzed = try analyzeLine(std.testing.allocator, source, source.len);
+    defer analyzed.deinit(std.testing.allocator);
+    const literal = analyzed.literal_prefix orelse return error.ExpectedLiteralPath;
     var sh: TestShell = .{ .host = .{}, .state = .{} };
     var builder: Builder = .{};
     defer builder.deinit(std.testing.allocator);
@@ -1512,12 +1639,13 @@ test "path completion expands tilde for lookup and preserves it in candidates" {
         std.testing.allocator,
         &builder,
         &sh,
-        "~/.config/ru",
-        "nvim ".len,
-        source.len,
+        literal.value,
+        literal.expands_leading_tilde,
+        analyzed.replace_start,
+        analyzed.replace_end,
         false,
     );
-    var application = try applyBuiltCandidates(std.testing.allocator, source, &builder);
+    var application = try applyBuiltCandidates(std.testing.allocator, source, &builder, analyzed);
     defer application.deinit(std.testing.allocator);
 
     const edit = switch (application) {
@@ -1526,4 +1654,327 @@ test "path completion expands tilde for lookup and preserves it in candidates" {
     };
     try std.testing.expectEqualStrings("~/.config/rush/", edit.replacement);
     try std.testing.expect(!edit.append_space);
+}
+
+const PathCompletionTestState = struct {
+    home: ?[]const u8 = null,
+
+    fn getVariable(self: PathCompletionTestState, name: []const u8) ?shell.state.Variable {
+        if (!std.mem.eql(u8, name, "HOME")) return null;
+        const home = self.home orelse return null;
+        return .{ .name = "HOME", .value = home };
+    }
+};
+
+const PathCompletionTestHost = struct {
+    expected_path: []const u8,
+    entry_name: []const u8,
+    entry_kind: host.FileKind,
+
+    pub fn listDir(self: *PathCompletionTestHost, allocator: std.mem.Allocator, path: []const u8) !host.ListDirResult {
+        try std.testing.expectEqualStrings(self.expected_path, path);
+        const entries = try allocator.alloc(host.DirectoryEntry, 1);
+        errdefer allocator.free(entries);
+        entries[0] = .{
+            .name = try allocator.dupe(u8, self.entry_name),
+            .kind = self.entry_kind,
+        };
+        return .{ .allocator = allocator, .entries = entries };
+    }
+
+    pub fn fileTestStatusZ(_: *PathCompletionTestHost, _: [:0]const u8, _: bool) ?host.FileStatus {
+        unreachable;
+    }
+};
+
+const PathCompletionTestShell = struct {
+    host: PathCompletionTestHost,
+    state: PathCompletionTestState,
+    env: []const [*:0]const u8 = &.{},
+};
+
+fn expectPathCompletion(
+    source_text: []const u8,
+    expected_lookup_path: []const u8,
+    entry_name: []const u8,
+    entry_kind: host.FileKind,
+    home: ?[]const u8,
+    expected_replacement: []const u8,
+    expected_append_space: bool,
+) !void {
+    const analyzed = try analyzeLine(std.testing.allocator, source_text, source_text.len);
+    defer analyzed.deinit(std.testing.allocator);
+    const literal = analyzed.literal_prefix orelse return error.ExpectedLiteralPath;
+
+    var sh: PathCompletionTestShell = .{
+        .host = .{
+            .expected_path = expected_lookup_path,
+            .entry_name = entry_name,
+            .entry_kind = entry_kind,
+        },
+        .state = .{ .home = home },
+    };
+    var builder: Builder = .{};
+    defer builder.deinit(std.testing.allocator);
+    try appendPathCandidates(
+        std.testing.allocator,
+        &builder,
+        &sh,
+        literal.value,
+        literal.expands_leading_tilde,
+        analyzed.replace_start,
+        analyzed.replace_end,
+        false,
+    );
+
+    var application = try applyBuiltCandidates(std.testing.allocator, source_text, &builder, analyzed);
+    defer application.deinit(std.testing.allocator);
+    const edit = switch (application) {
+        .edit => |edit| edit,
+        else => return error.ExpectedSinglePathCompletion,
+    };
+    try std.testing.expectEqualStrings(expected_replacement, edit.replacement);
+    try std.testing.expectEqual(expected_append_space, edit.append_space);
+}
+
+test "path completion preserves a simple open quote and safely respells fallbacks" {
+    const Case = struct {
+        source: []const u8,
+        lookup_path: []const u8,
+        entry_name: []const u8,
+        entry_kind: host.FileKind = .file,
+        home: ?[]const u8 = null,
+        replacement: []const u8,
+        append_space: bool = true,
+    };
+    const cases = [_]Case{
+        .{
+            .source = "cat my",
+            .lookup_path = ".",
+            .entry_name = "my file.txt",
+            .replacement = "my\\ file.txt",
+        },
+        .{
+            .source = "cat my\\ f",
+            .lookup_path = ".",
+            .entry_name = "my file.txt",
+            .replacement = "my\\ file.txt",
+        },
+        .{
+            .source = "cat 'my f",
+            .lookup_path = ".",
+            .entry_name = "my file.txt",
+            .replacement = "'my file.txt'",
+        },
+        .{
+            .source = "cat \"my f",
+            .lookup_path = ".",
+            .entry_name = "my file.txt",
+            .replacement = "\"my file.txt\"",
+        },
+        .{
+            .source = "cat $'my\\x20f",
+            .lookup_path = ".",
+            .entry_name = "my file.txt",
+            .replacement = "$'my file.txt'",
+        },
+        .{
+            .source = "cat 'it",
+            .lookup_path = ".",
+            .entry_name = "it's here",
+            .replacement = "'it'\\''s here'",
+        },
+        .{
+            .source = "cat \"cash",
+            .lookup_path = ".",
+            .entry_name = "cash$ file",
+            .replacement = "\"cash\\$ file\"",
+        },
+        .{
+            .source = "cat $'line",
+            .lookup_path = ".",
+            .entry_name = "line\nbreak",
+            .replacement = "$'line\\nbreak'",
+        },
+        .{
+            .source = "cat pre\"my f",
+            .lookup_path = ".",
+            .entry_name = "premy file",
+            .replacement = "premy\\ file",
+        },
+        .{
+            .source = "cat 'my 'f",
+            .lookup_path = ".",
+            .entry_name = "my file",
+            .replacement = "my\\ file",
+        },
+        .{
+            .source = "cat my\\ dir/ch",
+            .lookup_path = "my dir",
+            .entry_name = "child file",
+            .replacement = "my\\ dir/child\\ file",
+        },
+        .{
+            .source = "cat 'my dir/ch",
+            .lookup_path = "my dir",
+            .entry_name = "child file",
+            .replacement = "'my dir/child file'",
+        },
+        .{
+            .source = "cat ~/my",
+            .lookup_path = "/home/alice",
+            .entry_name = "my file",
+            .home = "/home/alice",
+            .replacement = "~/my\\ file",
+        },
+        .{
+            .source = "cat ~/\"my",
+            .lookup_path = "/home/alice",
+            .entry_name = "my file",
+            .home = "/home/alice",
+            .replacement = "~/my\\ file",
+        },
+        .{
+            .source = "cat '~/my",
+            .lookup_path = "~",
+            .entry_name = "my file",
+            .replacement = "'~/my file'",
+        },
+        .{
+            .source = "cat \\~/my",
+            .lookup_path = "~",
+            .entry_name = "my file",
+            .replacement = "\\~/my\\ file",
+        },
+        .{
+            .source = "cd my",
+            .lookup_path = ".",
+            .entry_name = "my dir",
+            .entry_kind = .directory,
+            .replacement = "my\\ dir/",
+            .append_space = false,
+        },
+        .{
+            .source = "cd 'my",
+            .lookup_path = ".",
+            .entry_name = "my dir",
+            .entry_kind = .directory,
+            .replacement = "'my dir/",
+            .append_space = false,
+        },
+    };
+    for (cases) |case| {
+        try expectPathCompletion(
+            case.source,
+            case.lookup_path,
+            case.entry_name,
+            case.entry_kind,
+            case.home,
+            case.replacement,
+            case.append_space,
+        );
+    }
+}
+
+test "ambiguous path candidates preserve open quoting in their insert text" {
+    const source_text = "cat 'my";
+    const analyzed = try analyzeLine(std.testing.allocator, source_text, source_text.len);
+    defer analyzed.deinit(std.testing.allocator);
+
+    var builder: Builder = .{};
+    defer builder.deinit(std.testing.allocator);
+    for ([_][]const u8{ "my file", "my folder" }) |value| {
+        try builder.append(std.testing.allocator, .{
+            .value = value,
+            .kind = .file,
+            .replace_start = analyzed.replace_start,
+            .replace_end = analyzed.replace_end,
+        });
+    }
+
+    var application = try applyBuiltCandidates(std.testing.allocator, source_text, &builder, analyzed);
+    defer application.deinit(std.testing.allocator);
+    const candidates = switch (application) {
+        .ambiguous => |candidates| candidates,
+        else => return error.ExpectedAmbiguousPathCompletion,
+    };
+    try std.testing.expectEqual(@as(usize, 2), candidates.len);
+    try std.testing.expectEqualStrings("my file", candidates[0].value);
+    try std.testing.expectEqualStrings("'my file'", candidates[0].insert.?);
+    try std.testing.expectEqualStrings("my folder", candidates[1].value);
+    try std.testing.expectEqualStrings("'my folder'", candidates[1].insert.?);
+}
+
+test "provider file candidates receive shell-safe inserts at the shared boundary" {
+    const source_text = "git add my";
+    const analyzed = try analyzeLine(std.testing.allocator, source_text, source_text.len);
+    defer analyzed.deinit(std.testing.allocator);
+
+    var builder: Builder = .{};
+    defer builder.deinit(std.testing.allocator);
+    try builder.append(std.testing.allocator, .{
+        .value = "my file",
+        .kind = .file,
+        .replace_start = analyzed.replace_start,
+        .replace_end = analyzed.replace_end,
+    });
+
+    var application = try applyBuiltCandidates(std.testing.allocator, source_text, &builder, analyzed);
+    defer application.deinit(std.testing.allocator);
+    const edit = switch (application) {
+        .edit => |edit| edit,
+        else => return error.ExpectedProviderPathCompletion,
+    };
+    try std.testing.expectEqualStrings("my\\ file", edit.replacement);
+}
+
+test "provider-supplied inserts remain authoritative" {
+    const source_text = "git add my";
+    const analyzed = try analyzeLine(std.testing.allocator, source_text, source_text.len);
+    defer analyzed.deinit(std.testing.allocator);
+
+    var builder: Builder = .{};
+    defer builder.deinit(std.testing.allocator);
+    try builder.append(std.testing.allocator, .{
+        .value = "my file",
+        .insert = "'my file'",
+        .kind = .file,
+        .replace_start = analyzed.replace_start,
+        .replace_end = analyzed.replace_end,
+    });
+
+    var application = try applyBuiltCandidates(std.testing.allocator, source_text, &builder, analyzed);
+    defer application.deinit(std.testing.allocator);
+    const edit = switch (application) {
+        .edit => |edit| edit,
+        else => return error.ExpectedProviderPathCompletion,
+    };
+    try std.testing.expectEqualStrings("'my file'", edit.replacement);
+}
+
+test "quoted path candidates keep provider suffixes outside the quote" {
+    const source_text = "git add 'my";
+    const analyzed = try analyzeLine(std.testing.allocator, source_text, source_text.len);
+    defer analyzed.deinit(std.testing.allocator);
+
+    var builder: Builder = .{};
+    defer builder.deinit(std.testing.allocator);
+    try builder.append(std.testing.allocator, .{
+        .value = "my file",
+        .suffix = ",",
+        .removable_suffix = true,
+        .kind = .file,
+        .replace_start = analyzed.replace_start,
+        .replace_end = analyzed.replace_end,
+    });
+
+    var application = try applyBuiltCandidates(std.testing.allocator, source_text, &builder, analyzed);
+    defer application.deinit(std.testing.allocator);
+    const edit = switch (application) {
+        .edit => |edit| edit,
+        else => return error.ExpectedProviderPathCompletion,
+    };
+    try std.testing.expectEqualStrings("'my file',", edit.replacement);
+    try std.testing.expectEqualStrings(",", edit.suffix.?);
+    try std.testing.expect(edit.removable_suffix);
 }

--- a/src/completion.zig
+++ b/src/completion.zig
@@ -307,8 +307,7 @@ fn applyBuiltCandidates(
     for (candidates) |*candidate| {
         try preparePathCandidateInsert(allocator, candidate, analyzed);
         const query = if (analyzed.literal_query) |literal|
-            if (candidateUsesLiteralQuery(candidate.*) and
-                candidate.replace_start == analyzed.replace_start and
+            if (candidate.replace_start == analyzed.replace_start and
                 candidate.replace_end == analyzed.replace_end)
                 literal.value
             else
@@ -320,11 +319,6 @@ fn applyBuiltCandidates(
         }
     }
     return editor_completion.applyCandidates(allocator, matches.items);
-}
-
-fn candidateUsesLiteralQuery(candidate: editor_completion.Candidate) bool {
-    return candidate.kind == .file or candidate.kind == .directory or
-        (candidate.kind == .command and candidate.insert != null);
 }
 
 fn preparePathCandidateInsert(
@@ -1926,6 +1920,30 @@ test "provider file candidates receive shell-safe inserts at the shared boundary
         else => return error.ExpectedProviderPathCompletion,
     };
     try std.testing.expectEqualStrings("my\\ file", edit.replacement);
+}
+
+test "literal provider prefixes match plain candidates by semantic value" {
+    const source_text = "tool 'ma";
+    const analyzed = try analyzeLine(std.testing.allocator, source_text, source_text.len);
+    defer analyzed.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("ma", analyzed.literal_prefix.?.value);
+
+    var builder: Builder = .{};
+    defer builder.deinit(std.testing.allocator);
+    try builder.append(std.testing.allocator, .{
+        .value = "main",
+        .kind = .plain,
+        .replace_start = analyzed.replace_start,
+        .replace_end = analyzed.replace_end,
+    });
+
+    var application = try applyBuiltCandidates(std.testing.allocator, source_text, &builder, analyzed);
+    defer application.deinit(std.testing.allocator);
+    const edit = switch (application) {
+        .edit => |edit| edit,
+        else => return error.ExpectedProviderCompletion,
+    };
+    try std.testing.expectEqualStrings("main", edit.replacement);
 }
 
 test "provider-supplied inserts remain authoritative" {

--- a/src/editor/path.zig
+++ b/src/editor/path.zig
@@ -2,6 +2,8 @@
 
 const std = @import("std");
 
+const word_quoting = @import("../shell/word_quoting.zig");
+
 pub const Command = enum {
     list,
     complete,
@@ -95,6 +97,17 @@ pub fn replacementStyle(word: []const u8) ReplacementStyle {
     return .unquoted;
 }
 
+/// Escalates an unquoted replacement style to backslash escaping when any
+/// match would otherwise split into multiple shell words. Styles derived from
+/// quoted input keep their existing convention.
+pub fn effectiveReplacementStyle(style: ReplacementStyle, matches: []const []const u8) ReplacementStyle {
+    if (style != .unquoted) return style;
+    for (matches) |match| {
+        if (word_quoting.needsEscaping(match, .{})) return .backslash_escaped;
+    }
+    return .unquoted;
+}
+
 fn quoteMatches(allocator: std.mem.Allocator, matches: []const []const u8, style: ReplacementStyle) ![][]const u8 {
     const quoted = try allocator.alloc([]const u8, matches.len);
     errdefer allocator.free(quoted);
@@ -111,62 +124,9 @@ fn quoteMatches(allocator: std.mem.Allocator, matches: []const []const u8, style
 fn shellQuoteMatch(allocator: std.mem.Allocator, text: []const u8, style: ReplacementStyle) ![]const u8 {
     return switch (style) {
         .unquoted => allocator.dupe(u8, text),
-        .single_quoted => shellSingleQuote(allocator, text),
-        .double_quoted => shellDoubleQuote(allocator, text),
-        .backslash_escaped => shellBackslashEscape(allocator, text),
-    };
-}
-
-fn shellSingleQuote(allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-    try out.append(allocator, '\'');
-    for (text) |byte| {
-        if (byte == '\'') {
-            try out.appendSlice(allocator, "'\\''");
-        } else {
-            try out.append(allocator, byte);
-        }
-    }
-    try out.append(allocator, '\'');
-    return out.toOwnedSlice(allocator);
-}
-
-fn shellDoubleQuote(allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-    try out.append(allocator, '"');
-    for (text) |byte| {
-        switch (byte) {
-            '"', '\\', '$', '`' => {
-                try out.append(allocator, '\\');
-                try out.append(allocator, byte);
-            },
-            else => try out.append(allocator, byte),
-        }
-    }
-    try out.append(allocator, '"');
-    return out.toOwnedSlice(allocator);
-}
-
-fn shellBackslashEscape(allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
-    if (text.len == 0 or std.mem.indexOfScalar(u8, text, '\n') != null) return shellSingleQuote(allocator, text);
-
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-    for (text, 0..) |byte, index| {
-        if (!isSafeBackslashEscapedByte(byte) or (index == 0 and (byte == '~' or byte == '#'))) {
-            try out.append(allocator, '\\');
-        }
-        try out.append(allocator, byte);
-    }
-    return out.toOwnedSlice(allocator);
-}
-
-fn isSafeBackslashEscapedByte(byte: u8) bool {
-    return std.ascii.isAlphanumeric(byte) or switch (byte) {
-        '/', '.', '_', '-', '+', ',', ':', '@', '%', '=' => true,
-        else => false,
+        .single_quoted => word_quoting.singleQuote(allocator, text),
+        .double_quoted => word_quoting.doubleQuote(allocator, text),
+        .backslash_escaped => word_quoting.escape(allocator, text, .{}),
     };
 }
 
@@ -235,4 +195,22 @@ fn isAsciiWhitespace(byte: u8) bool {
         ' ', '\t', '\n', '\r' => true,
         else => false,
     };
+}
+
+test "effective replacement style escalates only from unquoted" {
+    const spacey_matches = [_][]const u8{"rush vi file"};
+    const safe_matches = [_][]const u8{"rush-vi-file"};
+
+    try std.testing.expectEqual(
+        ReplacementStyle.backslash_escaped,
+        effectiveReplacementStyle(.unquoted, &spacey_matches),
+    );
+    try std.testing.expectEqual(
+        ReplacementStyle.unquoted,
+        effectiveReplacementStyle(.unquoted, &safe_matches),
+    );
+    try std.testing.expectEqual(
+        ReplacementStyle.single_quoted,
+        effectiveReplacementStyle(.single_quoted, &spacey_matches),
+    );
 }

--- a/src/editor/session.zig
+++ b/src/editor/session.zig
@@ -873,15 +873,19 @@ pub const LineSession = struct {
     /// Borrows the request and matches for the duration of the call.
     pub fn applyPathExpansion(self: *LineSession, request: PathExpansionRequest, matches: PathExpansionMatches) !bool {
         if (request.command == .list or matches.items.len == 0) return false;
+        // Matches found on disk may need quoting even when the typed word was
+        // plain; an unquoted replacement containing spaces would split into
+        // several shell words.
+        const replacement_style = path.effectiveReplacementStyle(request.replacement_style, matches.items);
         const replacement = switch (request.command) {
             .list => unreachable,
             .complete => try pathExpansionCompletionReplacement(
                 self.allocator,
                 request.word,
                 matches.items,
-                request.replacement_style,
+                replacement_style,
             ),
-            .expand_all => try pathExpansionAllReplacement(self.allocator, matches.items, request.replacement_style),
+            .expand_all => try pathExpansionAllReplacement(self.allocator, matches.items, replacement_style),
         };
         defer self.allocator.free(replacement);
         if (std.mem.eql(u8, request.word, replacement)) return false;
@@ -4774,6 +4778,30 @@ test "vi pathname completion requotes replacements for quoted shell words" {
         .replacement_style = .double_quoted,
     }, .{ .items = &.{"rush vi dir/"} }));
     try std.testing.expectEqualStrings("cd \"rush vi dir/\"", dir.editor.buffer.text());
+}
+
+test "vi pathname completion escapes spacey matches for unquoted words" {
+    var file = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
+    defer file.deinit();
+    try file.editor.buffer.replace("cat rush");
+    try std.testing.expect(try file.applyPathExpansion(.{
+        .command = .complete,
+        .word = "rush",
+        .replace_start = "cat ".len,
+        .replace_end = "cat rush".len,
+    }, .{ .items = &.{"rush vi file"} }));
+    try std.testing.expectEqualStrings("cat rush\\ vi\\ file ", file.editor.buffer.text());
+
+    var all = try LineSession.initWithEditingMode(std.testing.allocator, .{ .bytes = "$ " }, .{}, .vi);
+    defer all.deinit();
+    try all.editor.buffer.replace("printf rush*");
+    try std.testing.expect(try all.applyPathExpansion(.{
+        .command = .expand_all,
+        .word = "rush*",
+        .replace_start = "printf ".len,
+        .replace_end = "printf rush*".len,
+    }, .{ .items = &.{ "rush vi a", "rush vi b" } }));
+    try std.testing.expectEqualStrings("printf rush\\ vi\\ a rush\\ vi\\ b", all.editor.buffer.text());
 }
 
 test "vi pathname star expands all matches and listing formats matches" {

--- a/src/extensions/rush.zig
+++ b/src/extensions/rush.zig
@@ -53,7 +53,10 @@ pub const CompletionParsedOperand = struct {
 /// `rush_complete` until they are taken or the context is deinitialized.
 pub const CompletionContext = struct {
     allocator: std.mem.Allocator,
+    /// Quote-removed literal prefix when available; otherwise the raw prefix.
     prefix: []const u8,
+    /// Whether `prefix` began with an unquoted supported tilde form.
+    expand_leading_tilde: bool,
     replace_start: usize,
     replace_end: usize,
     argument_index: usize,
@@ -67,6 +70,7 @@ pub const CompletionContext = struct {
     pub fn init(
         allocator: std.mem.Allocator,
         prefix: []const u8,
+        expand_leading_tilde: bool,
         replace_start: usize,
         replace_end: usize,
         argument_index: usize,
@@ -78,6 +82,7 @@ pub const CompletionContext = struct {
         return .{
             .allocator = allocator,
             .prefix = prefix,
+            .expand_leading_tilde = expand_leading_tilde,
             .replace_start = replace_start,
             .replace_end = replace_end,
             .argument_index = argument_index,
@@ -1374,11 +1379,10 @@ fn appendPathCompletionCandidates(context: *CompletionContext, sh: anytype, dire
     const entry_prefix = if (slash) |index| context.prefix[index + 1 ..] else context.prefix;
     // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
     const unexpanded_dir_path = if (dir_prefix.len == 0) "." else if (std.mem.eql(u8, dir_prefix, "/")) "/" else std.mem.trimEnd(u8, dir_prefix, "/");
-    const dir_path = try completion_path.expandLeadingTilde(
-        context.allocator,
-        unexpanded_dir_path,
-        shellValue(sh, "HOME"),
-    );
+    const dir_path = if (context.expand_leading_tilde)
+        try completion_path.expandLeadingTilde(context.allocator, unexpanded_dir_path, shellValue(sh, "HOME"))
+    else
+        try context.allocator.dupe(u8, unexpanded_dir_path);
     defer context.allocator.free(dir_path);
     var entries = sh.host.listDir(context.allocator, dir_path) catch return;
     defer entries.deinit();
@@ -1426,6 +1430,7 @@ test "rush_complete path provider leaves case-insensitive filtering to the match
     var context: CompletionContext = .init(
         std.testing.allocator,
         "agents",
+        false,
         0,
         "agents".len,
         0,
@@ -1448,6 +1453,59 @@ test "rush_complete path provider leaves case-insensitive filtering to the match
         context.prefix,
         .prefixOnly(),
     ).?);
+}
+
+test "rush_complete path provider expands only an eligible leading tilde" {
+    const TestState = struct {
+        const Self = @This();
+
+        fn getVariable(_: Self, name: []const u8) ?shell.state.Variable {
+            if (!std.mem.eql(u8, name, "HOME")) return null;
+            return .{ .name = "HOME", .value = "/home/alice" };
+        }
+    };
+    const TestHost = struct {
+        const Self = @This();
+
+        expected_path: []const u8,
+
+        pub fn listDir(self: *Self, allocator: std.mem.Allocator, path: []const u8) !host.ListDirResult {
+            try std.testing.expectEqualStrings(self.expected_path, path);
+            return .{ .allocator = allocator, .entries = try allocator.alloc(host.DirectoryEntry, 0) };
+        }
+    };
+    const TestShell = struct {
+        host: TestHost,
+        state: TestState,
+        env: []const [*:0]const u8 = &.{},
+    };
+    const Case = struct {
+        expand_leading_tilde: bool,
+        expected_path: []const u8,
+    };
+    const cases = [_]Case{
+        .{ .expand_leading_tilde = true, .expected_path = "/home/alice" },
+        .{ .expand_leading_tilde = false, .expected_path = "~" },
+    };
+
+    for (cases) |case| {
+        var context: CompletionContext = .init(
+            std.testing.allocator,
+            "~/my",
+            case.expand_leading_tilde,
+            0,
+            "~/my".len,
+            0,
+            false,
+            "item",
+            &.{},
+            &.{},
+        );
+        defer context.deinit();
+        var sh: TestShell = .{ .host = .{ .expected_path = case.expected_path }, .state = .{} };
+
+        try appendPathCompletionCandidates(&context, &sh, false);
+    }
 }
 
 fn appendCompletionCandidate(

--- a/src/extensions/rush.zig
+++ b/src/extensions/rush.zig
@@ -53,7 +53,9 @@ pub const CompletionParsedOperand = struct {
 /// `rush_complete` until they are taken or the context is deinitialized.
 pub const CompletionContext = struct {
     allocator: std.mem.Allocator,
-    /// Quote-removed literal prefix when available; otherwise the raw prefix.
+    /// Semantic prefix after quote removal and escape processing when entirely
+    /// literal; otherwise the raw prefix. This is provider input, not the final
+    /// editor insertion spelling.
     prefix: []const u8,
     /// Whether `prefix` began with an unquoted supported tilde form.
     expand_leading_tilde: bool,

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -17,6 +17,7 @@ pub const result = @import("shell/result.zig");
 pub const source = @import("shell/source.zig");
 pub const state = @import("shell/state.zig");
 pub const token = @import("shell/token.zig");
+pub const word_quoting = @import("shell/word_quoting.zig");
 
 pub const Shell = shell_factory.Shell;
 pub const ShellWithBuiltins = shell_factory.ShellWithBuiltins;

--- a/src/shell/word_quoting.zig
+++ b/src/shell/word_quoting.zig
@@ -1,9 +1,10 @@
 //! Literal shell-word analysis and safe word spelling.
 //!
-//! Completion uses the real lexer and word parser to remove shell quoting from
-//! partially typed literal words. Dynamic expansions are deliberately rejected:
-//! their values are unavailable until evaluation and must not be mistaken for
-//! literal filesystem paths.
+//! Completion uses the real lexer and word parser to derive semantic values
+//! from partially typed literal words. Quote and escape syntax is discarded
+//! only for matching and lookup; insertion may restore and close a simple
+//! leading open quote. Dynamic expansions are deliberately rejected because
+//! their values are unavailable until evaluation.
 
 const std = @import("std");
 
@@ -19,8 +20,9 @@ pub const LiteralWord = struct {
     /// Whether the supported leading `~` or `~/` spelling is unquoted and may
     /// be expanded during filesystem lookup and later shell evaluation.
     expands_leading_tilde: bool,
-    /// The quote style to preserve when one pending quote begins the word.
-    /// Mixed quoting deliberately falls back to canonical escaping.
+    /// A pending quote style that can be restored when spelling a completion.
+    /// Only a quote beginning the word is preserved; mixed quoting deliberately
+    /// falls back to canonical escaping.
     open_quote: ?QuoteStyle,
 
     pub fn deinit(self: LiteralWord, allocator: std.mem.Allocator) void {
@@ -28,11 +30,10 @@ pub const LiteralWord = struct {
     }
 };
 
-/// Resolves quote removal and escape processing for a possibly incomplete
-/// literal shell word. Open single, double, and dollar-single quotes are closed
-/// synthetically before parsing. Returns null when the word contains parameter,
-/// command, arithmetic, or process substitution, or cannot otherwise be parsed
-/// as one literal word.
+/// Derives the semantic value of a possibly incomplete literal shell word.
+/// Pending single, double, and dollar-single quotes are closed only in temporary
+/// parser input and recorded in `open_quote` for later insertion. Returns null
+/// when evaluation would be required or the input is not one literal word.
 pub fn parseLiteralWord(
     allocator: std.mem.Allocator,
     raw: []const u8,
@@ -42,7 +43,7 @@ pub fn parseLiteralWord(
     const arena_allocator = arena.allocator();
 
     const pending_quote = try findPendingQuote(arena_allocator, raw);
-    const parse_text = try closePendingQuote(arena_allocator, raw, pending_quote);
+    const parse_text = try closePendingQuoteForParsing(arena_allocator, raw, pending_quote);
     const word = parser.parseWordExpansionText(arena_allocator, parse_text, .{}) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return null,
@@ -104,7 +105,7 @@ fn findPendingQuote(allocator: std.mem.Allocator, raw: []const u8) error{OutOfMe
     return null;
 }
 
-fn closePendingQuote(
+fn closePendingQuoteForParsing(
     allocator: std.mem.Allocator,
     raw: []const u8,
     pending_quote: ?PendingQuote,
@@ -355,7 +356,7 @@ fn isSafeUnquotedByte(byte: u8) bool {
     };
 }
 
-test "literal word parsing follows shell quote removal" {
+test "literal word parsing derives semantic values from shell spelling" {
     const Case = struct {
         raw: []const u8,
         value: []const u8,

--- a/src/shell/word_quoting.zig
+++ b/src/shell/word_quoting.zig
@@ -1,0 +1,485 @@
+//! Literal shell-word analysis and safe word spelling.
+//!
+//! Completion uses the real lexer and word parser to remove shell quoting from
+//! partially typed literal words. Dynamic expansions are deliberately rejected:
+//! their values are unavailable until evaluation and must not be mistaken for
+//! literal filesystem paths.
+
+const std = @import("std");
+
+const ast = @import("ast.zig");
+const lexer = @import("lexer.zig");
+const parser = @import("parser.zig");
+const source = @import("source.zig");
+
+/// A shell word whose value is fully determined by its literal and quoted
+/// parts. `value` is allocator-owned.
+pub const LiteralWord = struct {
+    value: []const u8,
+    /// Whether the supported leading `~` or `~/` spelling is unquoted and may
+    /// be expanded during filesystem lookup and later shell evaluation.
+    expands_leading_tilde: bool,
+    /// The quote style to preserve when one pending quote begins the word.
+    /// Mixed quoting deliberately falls back to canonical escaping.
+    open_quote: ?QuoteStyle,
+
+    pub fn deinit(self: LiteralWord, allocator: std.mem.Allocator) void {
+        allocator.free(self.value);
+    }
+};
+
+/// Resolves quote removal and escape processing for a possibly incomplete
+/// literal shell word. Open single, double, and dollar-single quotes are closed
+/// synthetically before parsing. Returns null when the word contains parameter,
+/// command, arithmetic, or process substitution, or cannot otherwise be parsed
+/// as one literal word.
+pub fn parseLiteralWord(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+) error{OutOfMemory}!?LiteralWord {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    const pending_quote = try findPendingQuote(arena_allocator, raw);
+    const parse_text = try closePendingQuote(arena_allocator, raw, pending_quote);
+    const word = parser.parseWordExpansionText(arena_allocator, parse_text, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
+
+    var value: std.ArrayList(u8) = .empty;
+    errdefer value.deinit(allocator);
+    if (!try appendLiteralWord(allocator, &value, word)) {
+        value.deinit(allocator);
+        return null;
+    }
+    if (std.mem.indexOfScalar(u8, value.items, 0) != null) {
+        value.deinit(allocator);
+        return null;
+    }
+    return .{
+        .value = try value.toOwnedSlice(allocator),
+        .expands_leading_tilde = expandsLeadingTilde(raw),
+        .open_quote = if (pending_quote) |pending|
+            if (pending.start == 0) pending.style else null
+        else
+            null,
+    };
+}
+
+pub const QuoteStyle = enum {
+    single,
+    double,
+    dollar_single,
+};
+
+const PendingQuote = struct {
+    start: usize,
+    delimiter: u8,
+    style: QuoteStyle,
+};
+
+fn findPendingQuote(allocator: std.mem.Allocator, raw: []const u8) error{OutOfMemory}!?PendingQuote {
+    const src: source.Source = .{ .id = 0, .kind = .interactive, .name = "literal word", .text = raw };
+    var trivia: std.ArrayList(lexer.Trivia) = .empty;
+    defer trivia.deinit(allocator);
+    _ = try lexer.lexWithTrivia(allocator, src, &trivia);
+
+    for (trivia.items) |item| {
+        if (item.kind != .pending_quote or item.end != raw.len or item.start >= item.end) continue;
+        const opener = raw[item.start];
+        if (opener == '$') {
+            std.debug.assert(item.start + 1 < raw.len);
+            std.debug.assert(raw[item.start + 1] == '\'');
+            return .{ .start = item.start, .delimiter = '\'', .style = .dollar_single };
+        }
+        std.debug.assert(opener == '\'' or opener == '"');
+        return .{
+            .start = item.start,
+            .delimiter = opener,
+            .style = if (opener == '\'') .single else .double,
+        };
+    }
+    return null;
+}
+
+fn closePendingQuote(
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    pending_quote: ?PendingQuote,
+) error{OutOfMemory}![]const u8 {
+    const pending = pending_quote orelse return raw;
+    return std.fmt.allocPrint(allocator, "{s}{c}", .{ raw, pending.delimiter });
+}
+
+fn appendLiteralWord(
+    allocator: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    word: ast.Word,
+) error{OutOfMemory}!bool {
+    return switch (word.data) {
+        .literal => |literal| appendLiteralBytes(allocator, output, literal),
+        .parts => |parts| appendLiteralParts(allocator, output, parts),
+        .declaration_array_assignment => false,
+    };
+}
+
+fn appendLiteralParts(
+    allocator: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    parts: []const ast.WordPart,
+) error{OutOfMemory}!bool {
+    for (parts) |part| switch (part) {
+        .literal, .escaped, .single_quoted => |literal| {
+            try output.appendSlice(allocator, literal);
+        },
+        .double_quoted => |quoted| if (!try appendLiteralParts(allocator, output, quoted)) return false,
+        .parameter, .command_substitution, .process_substitution, .arithmetic => return false,
+    };
+    return true;
+}
+
+fn appendLiteralBytes(
+    allocator: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    literal: []const u8,
+) error{OutOfMemory}!bool {
+    try output.appendSlice(allocator, literal);
+    return true;
+}
+
+fn expandsLeadingTilde(raw: []const u8) bool {
+    return raw.len != 0 and raw[0] == '~' and (raw.len == 1 or raw[1] == '/');
+}
+
+pub const EscapeOptions = struct {
+    /// Preserve a supported leading `~` or `~/` so later shell evaluation
+    /// performs the same expansion used for completion lookup.
+    preserve_leading_tilde: bool = false,
+};
+
+/// True when `text` cannot be inserted verbatim as one literal shell word.
+pub fn needsEscaping(text: []const u8, options: EscapeOptions) bool {
+    if (text.len == 0) return true;
+    const tilde_prefix_len = preservedTildePrefixLength(text, options);
+    var index: usize = 0;
+    while (index < text.len) {
+        if (utf8SequenceLengthAt(text, index)) |sequence_len| {
+            index += sequence_len;
+            continue;
+        }
+        const byte = text[index];
+        const leading_special = index == 0 and
+            ((byte == '~' and tilde_prefix_len == 0) or byte == '#');
+        if (leading_special or !isSafeUnquotedByte(byte)) return true;
+        index += 1;
+    }
+    return false;
+}
+
+/// Returns an allocator-owned safe spelling of `text`. Newlines use single
+/// quotes because an unquoted backslash-newline pair would disappear. When
+/// requested, a leading tilde prefix remains outside any generated quotes.
+pub fn escape(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    options: EscapeOptions,
+) error{OutOfMemory}![]const u8 {
+    std.debug.assert(std.mem.indexOfScalar(u8, text, 0) == null);
+    if (!needsEscaping(text, options)) return allocator.dupe(u8, text);
+    if (text.len == 0) return allocator.dupe(u8, "''");
+
+    const tilde_prefix_len = preservedTildePrefixLength(text, options);
+    if (std.mem.indexOfScalar(u8, text, '\n') != null) {
+        const quoted = try singleQuote(allocator, text[tilde_prefix_len..]);
+        defer allocator.free(quoted);
+        return std.mem.concat(allocator, u8, &.{ text[0..tilde_prefix_len], quoted });
+    }
+
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(allocator);
+    var index: usize = 0;
+    while (index < text.len) {
+        if (utf8SequenceLengthAt(text, index)) |sequence_len| {
+            try output.appendSlice(allocator, text[index .. index + sequence_len]);
+            index += sequence_len;
+            continue;
+        }
+        const byte = text[index];
+        const leading_special = index == 0 and
+            ((byte == '~' and tilde_prefix_len == 0) or byte == '#');
+        if (leading_special or !isSafeUnquotedByte(byte)) try output.append(allocator, '\\');
+        try output.append(allocator, byte);
+        index += 1;
+    }
+    return output.toOwnedSlice(allocator);
+}
+
+/// Returns an escaped allocator-owned spelling only when `text` cannot be
+/// inserted verbatim.
+pub fn escapeIfNeeded(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    options: EscapeOptions,
+) error{OutOfMemory}!?[]const u8 {
+    if (!needsEscaping(text, options)) return null;
+    return try escape(allocator, text, options);
+}
+
+/// Returns an allocator-owned single-quoted spelling of `text`.
+pub fn singleQuote(allocator: std.mem.Allocator, text: []const u8) error{OutOfMemory}![]const u8 {
+    return singleQuoteWithClosure(allocator, text, true);
+}
+
+fn singleQuoteWithClosure(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    close: bool,
+) error{OutOfMemory}![]const u8 {
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(allocator);
+    try output.append(allocator, '\'');
+    for (text) |byte| {
+        if (byte == '\'') {
+            try output.appendSlice(allocator, "'\\''");
+        } else {
+            try output.append(allocator, byte);
+        }
+    }
+    if (close) try output.append(allocator, '\'');
+    return output.toOwnedSlice(allocator);
+}
+
+/// Returns an allocator-owned double-quoted spelling of `text`.
+pub fn doubleQuote(allocator: std.mem.Allocator, text: []const u8) error{OutOfMemory}![]const u8 {
+    return doubleQuoteWithClosure(allocator, text, true);
+}
+
+fn doubleQuoteWithClosure(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    close: bool,
+) error{OutOfMemory}![]const u8 {
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(allocator);
+    try output.append(allocator, '"');
+    for (text) |byte| {
+        switch (byte) {
+            '$', '`', '"', '\\' => {
+                try output.append(allocator, '\\');
+                try output.append(allocator, byte);
+            },
+            else => try output.append(allocator, byte),
+        }
+    }
+    if (close) try output.append(allocator, '"');
+    return output.toOwnedSlice(allocator);
+}
+
+/// Returns an allocator-owned dollar-single-quoted spelling of `text`.
+pub fn dollarSingleQuote(allocator: std.mem.Allocator, text: []const u8) error{OutOfMemory}![]const u8 {
+    return dollarSingleQuoteWithClosure(allocator, text, true);
+}
+
+fn dollarSingleQuoteWithClosure(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    close: bool,
+) error{OutOfMemory}![]const u8 {
+    std.debug.assert(std.mem.indexOfScalar(u8, text, 0) == null);
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(allocator);
+    try output.appendSlice(allocator, "$'");
+    for (text) |byte| switch (byte) {
+        '\'' => try output.appendSlice(allocator, "\\'"),
+        '\\' => try output.appendSlice(allocator, "\\\\"),
+        '\n' => try output.appendSlice(allocator, "\\n"),
+        '\r' => try output.appendSlice(allocator, "\\r"),
+        '\t' => try output.appendSlice(allocator, "\\t"),
+        0x07 => try output.appendSlice(allocator, "\\a"),
+        0x08 => try output.appendSlice(allocator, "\\b"),
+        0x0b => try output.appendSlice(allocator, "\\v"),
+        0x0c => try output.appendSlice(allocator, "\\f"),
+        0x1b => try output.appendSlice(allocator, "\\e"),
+        0x01...0x06, 0x0e...0x1a, 0x1c...0x1f, 0x7f => {
+            const hex = "0123456789ABCDEF";
+            try output.appendSlice(allocator, "\\x");
+            try output.append(allocator, hex[byte >> 4]);
+            try output.append(allocator, hex[byte & 0x0f]);
+        },
+        else => try output.append(allocator, byte),
+    };
+    if (close) try output.append(allocator, '\'');
+    return output.toOwnedSlice(allocator);
+}
+
+pub const QuoteOptions = struct {
+    /// Close the generated quote. Leave false only when more literal pathname
+    /// segments will be appended to the same shell word.
+    close: bool = true,
+};
+
+/// Returns an allocator-owned quoted spelling using `style` and `options`.
+pub fn quote(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    style: QuoteStyle,
+    options: QuoteOptions,
+) error{OutOfMemory}![]const u8 {
+    return switch (style) {
+        .single => singleQuoteWithClosure(allocator, text, options.close),
+        .double => doubleQuoteWithClosure(allocator, text, options.close),
+        .dollar_single => dollarSingleQuoteWithClosure(allocator, text, options.close),
+    };
+}
+
+fn preservedTildePrefixLength(text: []const u8, options: EscapeOptions) usize {
+    if (!options.preserve_leading_tilde or text.len == 0 or text[0] != '~') return 0;
+    if (text.len == 1) return 1;
+    return if (text[1] == '/') 2 else 0;
+}
+
+fn utf8SequenceLengthAt(text: []const u8, index: usize) ?usize {
+    if (text[index] < 0x80) return null;
+    const sequence_len: usize = std.unicode.utf8ByteSequenceLength(text[index]) catch return null;
+    const end = index + sequence_len;
+    if (end > text.len or !std.unicode.utf8ValidateSlice(text[index..end])) return null;
+    return sequence_len;
+}
+
+fn isSafeUnquotedByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or switch (byte) {
+        '/', '.', '_', '-', '+', ',', ':', '@', '%', '=', '~', '#' => true,
+        else => false,
+    };
+}
+
+test "literal word parsing follows shell quote removal" {
+    const Case = struct {
+        raw: []const u8,
+        value: []const u8,
+        expands_leading_tilde: bool = false,
+        open_quote: ?QuoteStyle = null,
+    };
+    const cases = [_]Case{
+        .{ .raw = "notes.md", .value = "notes.md" },
+        .{ .raw = "my\\ file", .value = "my file" },
+        .{ .raw = "'my file", .value = "my file", .open_quote = .single },
+        .{ .raw = "\"my file", .value = "my file", .open_quote = .double },
+        .{ .raw = "$'my\\x20file", .value = "my file", .open_quote = .dollar_single },
+        .{ .raw = "~/'my file'", .value = "~/my file", .expands_leading_tilde = true },
+        .{ .raw = "\\~/file", .value = "~/file" },
+        .{ .raw = "\"~/file", .value = "~/file", .open_quote = .double },
+        .{ .raw = "prefix\"open", .value = "prefixopen" },
+        .{ .raw = "'closed'", .value = "closed" },
+        .{ .raw = "'\\$HOME'/file", .value = "\\$HOME/file" },
+    };
+    for (cases) |case| {
+        const parsed = (try parseLiteralWord(std.testing.allocator, case.raw)).?;
+        defer parsed.deinit(std.testing.allocator);
+        try std.testing.expectEqualStrings(case.value, parsed.value);
+        try std.testing.expectEqual(case.expands_leading_tilde, parsed.expands_leading_tilde);
+        try std.testing.expectEqual(case.open_quote, parsed.open_quote);
+    }
+}
+
+test "literal word parsing rejects dynamic expansions" {
+    try std.testing.expect((try parseLiteralWord(std.testing.allocator, "$HOME/file")) == null);
+    try std.testing.expect((try parseLiteralWord(std.testing.allocator, "\"$HOME/file")) == null);
+    try std.testing.expect((try parseLiteralWord(std.testing.allocator, "$(pwd)/file")) == null);
+    try std.testing.expect((try parseLiteralWord(std.testing.allocator, "$((1 + 1))/file")) == null);
+    try std.testing.expect((try parseLiteralWord(std.testing.allocator, "$'\\0'")) == null);
+}
+
+test "escaping produces one literal shell word" {
+    const Case = struct {
+        value: []const u8,
+        options: EscapeOptions = .{},
+        expected: []const u8,
+    };
+    const cases = [_]Case{
+        .{ .value = "notes.md", .expected = "notes.md" },
+        .{ .value = "my file", .expected = "my\\ file" },
+        .{ .value = "it's", .expected = "it\\'s" },
+        .{ .value = "a$b", .expected = "a\\$b" },
+        .{ .value = "a\\b", .expected = "a\\\\b" },
+        .{ .value = "tab\tname", .expected = "tab\\\tname" },
+        .{ .value = "glob*[x]?", .expected = "glob\\*\\[x\\]\\?" },
+        .{ .value = "semi;&|<>()", .expected = "semi\\;\\&\\|\\<\\>\\(\\)" },
+        .{ .value = "café.txt", .expected = "café.txt" },
+        .{ .value = "bad\xff name", .expected = "bad\\\xff\\ name" },
+        .{ .value = "#notes", .expected = "\\#notes" },
+        .{ .value = "dir/#notes", .expected = "dir/#notes" },
+        .{ .value = "~/my file", .expected = "\\~/my\\ file" },
+        .{
+            .value = "~/my file",
+            .options = .{ .preserve_leading_tilde = true },
+            .expected = "~/my\\ file",
+        },
+        .{ .value = "line\nbreak", .expected = "'line\nbreak'" },
+        .{
+            .value = "~/line\nbreak",
+            .options = .{ .preserve_leading_tilde = true },
+            .expected = "~/'line\nbreak'",
+        },
+        .{ .value = "", .expected = "''" },
+    };
+    for (cases) |case| {
+        const escaped = try escape(std.testing.allocator, case.value, case.options);
+        defer std.testing.allocator.free(escaped);
+        try std.testing.expectEqualStrings(case.expected, escaped);
+
+        const parsed = (try parseLiteralWord(std.testing.allocator, escaped)).?;
+        defer parsed.deinit(std.testing.allocator);
+        try std.testing.expectEqualStrings(case.value, parsed.value);
+    }
+}
+
+test "quote styles round trip literal bytes" {
+    const Case = struct {
+        style: QuoteStyle,
+        value: []const u8,
+        expected: []const u8,
+    };
+    const cases = [_]Case{
+        .{ .style = .single, .value = "it's here", .expected = "'it'\\''s here'" },
+        .{ .style = .double, .value = "a$b`c\"d\\e", .expected = "\"a\\$b\\`c\\\"d\\\\e\"" },
+        .{
+            .style = .dollar_single,
+            .value = "line\nquote'\ttail\x01",
+            .expected = "$'line\\nquote\\'\\ttail\\x01'",
+        },
+    };
+    for (cases) |case| {
+        const quoted = try quote(std.testing.allocator, case.value, case.style, .{});
+        defer std.testing.allocator.free(quoted);
+        try std.testing.expectEqualStrings(case.expected, quoted);
+
+        const parsed = (try parseLiteralWord(std.testing.allocator, quoted)).?;
+        defer parsed.deinit(std.testing.allocator);
+        try std.testing.expectEqualStrings(case.value, parsed.value);
+    }
+}
+
+test "open quote styles remain parseable for another path segment" {
+    const Case = struct {
+        style: QuoteStyle,
+        expected: []const u8,
+    };
+    const cases = [_]Case{
+        .{ .style = .single, .expected = "'my dir/" },
+        .{ .style = .double, .expected = "\"my dir/" },
+        .{ .style = .dollar_single, .expected = "$'my dir/" },
+    };
+    for (cases) |case| {
+        const quoted = try quote(std.testing.allocator, "my dir/", case.style, .{ .close = false });
+        defer std.testing.allocator.free(quoted);
+        try std.testing.expectEqualStrings(case.expected, quoted);
+
+        const parsed = (try parseLiteralWord(std.testing.allocator, quoted)).?;
+        defer parsed.deinit(std.testing.allocator);
+        try std.testing.expectEqualStrings("my dir/", parsed.value);
+        try std.testing.expectEqual(case.style, parsed.open_quote.?);
+    }
+}

--- a/website/docs/builtins/rush_complete.html
+++ b/website/docs/builtins/rush_complete.html
@@ -54,7 +54,7 @@
 
   <h2 id="context-variables"><a href="#context-variables">CONTEXT VARIABLES</a></h2>
   <dl>
-    <dt><code>rush_completion_prefix</code></dt><dd>The current token prefix that completion candidates should match.</dd>
+    <dt><code>rush_completion_prefix</code></dt><dd>The current token prefix that completion candidates should match. Rush removes shell quoting and escapes when the prefix is entirely literal; prefixes containing dynamic expansions remain in their raw form.</dd>
     <dt><code>rush_completion_argument_index</code></dt><dd>Zero-based positional argument index being completed.</dd>
     <dt><code>rush_completion_options_terminated</code></dt><dd><code>true</code> when <code>--</code> has been parsed, otherwise <code>false</code>.</dd>
     <dt><code>rush_completion_value_position</code></dt><dd><code>value</code> while completing an option value, otherwise <code>item</code>.</dd>

--- a/website/docs/builtins/rush_complete.html
+++ b/website/docs/builtins/rush_complete.html
@@ -54,7 +54,7 @@
 
   <h2 id="context-variables"><a href="#context-variables">CONTEXT VARIABLES</a></h2>
   <dl>
-    <dt><code>rush_completion_prefix</code></dt><dd>The current token prefix that completion candidates should match. Rush removes shell quoting and escapes when the prefix is entirely literal; prefixes containing dynamic expansions remain in their raw form.</dd>
+    <dt><code>rush_completion_prefix</code></dt><dd>The current token prefix that completion candidates should match. For an entirely literal prefix, this is the semantic value after shell quote removal and escape processing, so <code>'my f</code> is exposed as <code>my f</code>. This affects provider matching only: when applying a path candidate, Rush preserves and completes a simple leading open quote. Prefixes containing dynamic expansions remain in their raw form.</dd>
     <dt><code>rush_completion_argument_index</code></dt><dd>Zero-based positional argument index being completed.</dd>
     <dt><code>rush_completion_options_terminated</code></dt><dd><code>true</code> when <code>--</code> has been parsed, otherwise <code>false</code>.</dd>
     <dt><code>rush_completion_value_position</code></dt><dd><code>value</code> while completing an option value, otherwise <code>item</code>.</dd>

--- a/website/docs/completions.html
+++ b/website/docs/completions.html
@@ -52,6 +52,7 @@
     <dt><code>{ "builtin": "functions" }</code></dt><dd>Shell function-name completion, including <a href="configuration.html#autoloaded-functions">autoloadable functions</a> that have not been sourced yet.</dd>
     <dt><code>{ "function": "name" }</code></dt><dd>Run a Rush function in a hidden completion worker and collect candidates emitted by <code>rush_complete</code>.</dd>
   </dl>
+  <p>Path providers emit semantic path values rather than shell-escaped text. Rush protects shell syntax when inserting them, preserves one open single, double, or dollar-single quote at the start of the word, and uses canonical backslash escaping for mixed quoting. A completed file closes the preserved quote; a directory leaves it open for the next path segment.</p>
 
   <h2 id="dynamic-provider-functions"><a href="#dynamic-provider-functions">Dynamic provider functions</a></h2>
   <p>Reference a function from the manifest:</p>

--- a/website/docs/completions.html
+++ b/website/docs/completions.html
@@ -52,7 +52,7 @@
     <dt><code>{ "builtin": "functions" }</code></dt><dd>Shell function-name completion, including <a href="configuration.html#autoloaded-functions">autoloadable functions</a> that have not been sourced yet.</dd>
     <dt><code>{ "function": "name" }</code></dt><dd>Run a Rush function in a hidden completion worker and collect candidates emitted by <code>rush_complete</code>.</dd>
   </dl>
-  <p>Path providers emit semantic path values rather than shell-escaped text. Rush protects shell syntax when inserting them, preserves one open single, double, or dollar-single quote at the start of the word, and uses canonical backslash escaping for mixed quoting. A completed file closes the preserved quote; a directory leaves it open for the next path segment.</p>
+  <p>Path providers receive a semantic, quote-removed prefix when it is entirely literal and emit semantic path values rather than shell-escaped text. Quote removal is used only for matching and filesystem lookup; it does not determine the text inserted into the command line. At insertion, Rush protects shell syntax and preserves a simple open single, double, or dollar-single quote that begins the word. A completed file closes that quote, while a directory leaves it open for the next path segment. Mixed or already-closed quoting uses canonical backslash escaping.</p>
 
   <h2 id="dynamic-provider-functions"><a href="#dynamic-provider-functions">Dynamic provider functions</a></h2>
   <p>Reference a function from the manifest:</p>


### PR DESCRIPTION
Tab completing a filename with a space like `my file.txt` inserts verbatim which causes issues. Quoting also leaked into lookup: a typed prefix like `'my f` did not match the semantic filename `my file.txt`.

Rush now matches paths by their semantic values, then safely escapes or completes the user’s quoting when inserting filenames. The new flow is:
```
typed shell text → literal word parsing → semantic path lookup → safe shell insertion
```

Examples:
- `cat my<Tab> → cat my\ file.txt`
- `cat 'my f<Tab> → cat 'my file.txt'`
- `cat "my f<Tab> → cat "my file.txt"`
- `cat $'my\x20f<Tab> → cat $'my file.txt'`
- `cd 'my<Tab> → cd 'my dir/`: The quote remains open so another path segment can be completed.
- `cat pre"my f<Tab> → cat premy\ file`: Mixed quoting falls back to canonical escaping.
- `cat ~/my<Tab> → cat ~/my\ file`: Lookup uses $HOME, while insertion preserves the eligible tilde.
- A provider suffix produces `my file`, keeping the suffix outside the quote.

Dynamic expansions such as `$HOME/file` are not evaluated during literal analysis. Dynamic providers receive their raw prefix, while filesystem providers avoid guessing or introducing evaluation side effects. Explicit provider insertion text remains authoritative.

(This ended up much larger scope than I anticipated because of all the edge case handling, happy for this to just be a thought experiment on how rush should handle tab completing some of these edge cases. No amp thread to share for this, though was mostly generated via gpt-5.6 sol)