### PR TITLE
completion: treat symlink directories as directories

### DIFF
--- a/src/completion.zig
+++ b/src/completion.zig
@@ -1102,7 +1102,14 @@ fn appendPathCandidates(
     for (entries.entries) |entry| {
         if (entry.name.len == 0 or std.mem.eql(u8, entry.name, ".") or std.mem.eql(u8, entry.name, "..")) continue;
         if (!include_hidden and entry.name[0] == '.') continue;
-        const is_directory = try pathCandidateIsDirectory(allocator, sh, dir_prefix, expand_leading_tilde, entry);
+        const is_directory = try completion_path.pathCandidateIsDirectory(
+            allocator,
+            sh,
+            dir_prefix,
+            expand_leading_tilde,
+            shellValue(sh, "HOME"),
+            entry,
+        );
         if (directories_only and !is_directory) continue;
         const value = if (is_directory)
             try std.fmt.allocPrint(allocator, "{s}{s}/", .{ dir_prefix, entry.name })
@@ -1112,29 +1119,6 @@ fn appendPathCandidates(
         // ziglint-ignore: Z024 preserve existing readable expression shape; lint-only cleanup
         try builder.append(allocator, .{ .value = value, .display = entry.name, .kind = if (is_directory) .directory else .file, .replace_start = replace_start, .replace_end = replace_end, .append_space = !is_directory });
     }
-}
-
-fn pathCandidateIsDirectory(
-    allocator: std.mem.Allocator,
-    sh: anytype,
-    dir_prefix: []const u8,
-    expand_leading_tilde: bool,
-    entry: host.DirectoryEntry,
-) !bool {
-    if (entry.kind == .directory) return true;
-    if (entry.kind != .symlink and entry.kind != .other) return false;
-
-    const unexpanded_path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ dir_prefix, entry.name });
-    defer allocator.free(unexpanded_path);
-    const path = if (expand_leading_tilde)
-        try completion_path.expandLeadingTilde(allocator, unexpanded_path, shellValue(sh, "HOME"))
-    else
-        try allocator.dupe(u8, unexpanded_path);
-    defer allocator.free(path);
-    const path_z = try allocator.dupeZ(u8, path);
-    defer allocator.free(path_z);
-    const status = sh.host.fileTestStatusZ(path_z, true) orelse return false;
-    return status.kind == .directory;
 }
 
 fn shellValue(sh: anytype, name: []const u8) ?[]const u8 {
@@ -1588,6 +1572,129 @@ test "path completion follows symlinked directories before appending space" {
         else => return error.ExpectedSingleSymlinkDirectoryCompletion,
     };
     try std.testing.expectEqualStrings(".config/rush/", edit.replacement);
+    try std.testing.expect(!edit.append_space);
+}
+
+test "path completion treats file and broken symlinks as files" {
+    const TestState = struct {
+        const Self = @This();
+
+        fn getVariable(_: Self, _: []const u8) ?shell.state.Variable {
+            return null;
+        }
+    };
+    const TestHost = struct {
+        const Self = @This();
+
+        pub fn listDir(_: *Self, allocator: std.mem.Allocator, path: []const u8) !host.ListDirResult {
+            try std.testing.expectEqualStrings(".", path);
+            const entries = try allocator.alloc(host.DirectoryEntry, 2);
+            errdefer allocator.free(entries);
+            entries[0] = .{ .name = try allocator.dupe(u8, "linkfile"), .kind = .symlink };
+            entries[1] = .{ .name = try allocator.dupe(u8, "broken"), .kind = .symlink };
+            return .{ .allocator = allocator, .entries = entries };
+        }
+
+        pub fn fileTestStatusZ(_: *Self, path: [:0]const u8, follow_symlinks: bool) ?host.FileStatus {
+            std.testing.expect(follow_symlinks) catch unreachable;
+            if (std.mem.eql(u8, path, "linkfile")) return .{ .kind = .file };
+            return null;
+        }
+    };
+    const TestShell = struct {
+        host: TestHost,
+        state: TestState,
+        env: []const [*:0]const u8 = &.{},
+    };
+
+    const source = "cat linkf";
+    const analyzed = try analyzeLine(std.testing.allocator, source, source.len);
+    defer analyzed.deinit(std.testing.allocator);
+    const literal = analyzed.literal_prefix orelse return error.ExpectedLiteralPath;
+    var sh: TestShell = .{ .host = .{}, .state = .{} };
+    var builder: Builder = .{};
+    defer builder.deinit(std.testing.allocator);
+
+    try appendPathCandidates(
+        std.testing.allocator,
+        &builder,
+        &sh,
+        literal.value,
+        literal.expands_leading_tilde,
+        analyzed.replace_start,
+        analyzed.replace_end,
+        false,
+    );
+    var application = try applyBuiltCandidates(std.testing.allocator, source, &builder, analyzed);
+    defer application.deinit(std.testing.allocator);
+
+    const edit = switch (application) {
+        .edit => |edit| edit,
+        else => return error.ExpectedSingleFileSymlinkCompletion,
+    };
+    try std.testing.expectEqualStrings("linkfile", edit.replacement);
+    try std.testing.expect(edit.append_space);
+}
+
+test "directory-only path completion includes symlink directories" {
+    const TestState = struct {
+        const Self = @This();
+
+        fn getVariable(_: Self, _: []const u8) ?shell.state.Variable {
+            return null;
+        }
+    };
+    const TestHost = struct {
+        const Self = @This();
+
+        pub fn listDir(_: *Self, allocator: std.mem.Allocator, path: []const u8) !host.ListDirResult {
+            try std.testing.expectEqualStrings(".", path);
+            const entries = try allocator.alloc(host.DirectoryEntry, 2);
+            errdefer allocator.free(entries);
+            entries[0] = .{ .name = try allocator.dupe(u8, "linkdir"), .kind = .symlink };
+            entries[1] = .{ .name = try allocator.dupe(u8, "linkfile"), .kind = .symlink };
+            return .{ .allocator = allocator, .entries = entries };
+        }
+
+        pub fn fileTestStatusZ(_: *Self, path: [:0]const u8, follow_symlinks: bool) ?host.FileStatus {
+            std.testing.expect(follow_symlinks) catch unreachable;
+            if (std.mem.eql(u8, path, "linkdir")) return .{ .kind = .directory };
+            if (std.mem.eql(u8, path, "linkfile")) return .{ .kind = .file };
+            return null;
+        }
+    };
+    const TestShell = struct {
+        host: TestHost,
+        state: TestState,
+        env: []const [*:0]const u8 = &.{},
+    };
+
+    const source = "cd link";
+    const analyzed = try analyzeLine(std.testing.allocator, source, source.len);
+    defer analyzed.deinit(std.testing.allocator);
+    const literal = analyzed.literal_prefix orelse return error.ExpectedLiteralPath;
+    var sh: TestShell = .{ .host = .{}, .state = .{} };
+    var builder: Builder = .{};
+    defer builder.deinit(std.testing.allocator);
+
+    try appendPathCandidates(
+        std.testing.allocator,
+        &builder,
+        &sh,
+        literal.value,
+        literal.expands_leading_tilde,
+        analyzed.replace_start,
+        analyzed.replace_end,
+        true,
+    );
+    var application = try applyBuiltCandidates(std.testing.allocator, source, &builder, analyzed);
+    defer application.deinit(std.testing.allocator);
+
+    const edit = switch (application) {
+        .edit => |edit| edit,
+        else => return error.ExpectedSingleSymlinkDirectoryCompletion,
+    };
+    try std.testing.expectEqualStrings("linkdir/", edit.replacement);
     try std.testing.expect(!edit.append_space);
 }
 

--- a/src/completion_path.zig
+++ b/src/completion_path.zig
@@ -2,6 +2,8 @@
 
 const std = @import("std");
 
+const host = @import("host.zig");
+
 /// Expands the leading tilde forms supported by Rush while leaving candidate
 /// spelling to the caller. The returned path is always allocator-owned.
 pub fn expandLeadingTilde(
@@ -13,6 +15,37 @@ pub fn expandLeadingTilde(
     if (path.len == 0 or path[0] != '~') return allocator.dupe(u8, path);
     if (path.len != 1 and path[1] != '/') return allocator.dupe(u8, path);
     return std.fmt.allocPrint(allocator, "{s}{s}", .{ value, path[1..] });
+}
+
+/// Returns whether `entry` should complete as a directory.
+///
+/// Directory dirents are accepted as-is. Symlink and unknown (`.other`) dirents
+/// are classified by `sh.host.fileTestStatusZ` with follow-symlink enabled.
+/// A failed follow or non-directory target returns false. Temporary path
+/// buffers are allocated and freed before return. `home` is used only when
+/// `expand_leading_tilde` is set.
+pub fn pathCandidateIsDirectory(
+    allocator: std.mem.Allocator,
+    sh: anytype,
+    dir_prefix: []const u8,
+    expand_leading_tilde: bool,
+    home: ?[]const u8,
+    entry: host.DirectoryEntry,
+) !bool {
+    if (entry.kind == .directory) return true;
+    if (entry.kind != .symlink and entry.kind != .other) return false;
+
+    const unexpanded_path = try std.fmt.allocPrint(allocator, "{s}{s}", .{ dir_prefix, entry.name });
+    defer allocator.free(unexpanded_path);
+    const path = if (expand_leading_tilde)
+        try expandLeadingTilde(allocator, unexpanded_path, home)
+    else
+        try allocator.dupe(u8, unexpanded_path);
+    defer allocator.free(path);
+    const path_z = try allocator.dupeZ(u8, path);
+    defer allocator.free(path_z);
+    const status = sh.host.fileTestStatusZ(path_z, true) orelse return false;
+    return status.kind == .directory;
 }
 
 test "completion lookup expands only supported leading tilde forms" {
@@ -27,4 +60,84 @@ test "completion lookup expands only supported leading tilde forms" {
     const no_home = try expandLeadingTilde(std.testing.allocator, "~/src", null);
     defer std.testing.allocator.free(no_home);
     try std.testing.expectEqualStrings("~/src", no_home);
+}
+
+test "path candidates follow only symlink and unknown directory targets" {
+    const Host = struct {
+        const Self = @This();
+
+        expected_path: []const u8,
+        follow_kind: ?host.FileKind,
+        follow_called: *bool,
+
+        pub fn fileTestStatusZ(self: *Self, path: [:0]const u8, follow_symlinks: bool) ?host.FileStatus {
+            self.follow_called.* = true;
+            std.testing.expect(follow_symlinks) catch unreachable;
+            std.testing.expectEqualStrings(self.expected_path, path) catch unreachable;
+            return if (self.follow_kind) |kind| .{ .kind = kind } else null;
+        }
+    };
+    const Shell = struct {
+        host: Host,
+    };
+    const Case = struct {
+        kind: host.FileKind,
+        follow_kind: ?host.FileKind = null,
+        expect_directory: bool,
+        expect_follow: bool,
+        dir_prefix: []const u8 = "",
+        name: []const u8 = "target",
+        expected_path: []const u8 = "target",
+        expand_tilde: bool = false,
+        home: ?[]const u8 = null,
+    };
+    const cases = [_]Case{
+        .{ .kind = .directory, .expect_directory = true, .expect_follow = false },
+        .{ .kind = .file, .expect_directory = false, .expect_follow = false },
+        .{ .kind = .named_pipe, .expect_directory = false, .expect_follow = false },
+        .{ .kind = .symlink, .follow_kind = .directory, .expect_directory = true, .expect_follow = true },
+        .{ .kind = .symlink, .follow_kind = .file, .expect_directory = false, .expect_follow = true },
+        .{ .kind = .symlink, .follow_kind = null, .expect_directory = false, .expect_follow = true },
+        .{ .kind = .other, .follow_kind = .directory, .expect_directory = true, .expect_follow = true },
+        .{ .kind = .other, .follow_kind = .file, .expect_directory = false, .expect_follow = true },
+        .{
+            .kind = .symlink,
+            .follow_kind = .directory,
+            .expect_directory = true,
+            .expect_follow = true,
+            .dir_prefix = "~/",
+            .expected_path = "/home/alice/target",
+            .expand_tilde = true,
+            .home = "/home/alice",
+        },
+        .{
+            .kind = .symlink,
+            .follow_kind = .directory,
+            .expect_directory = true,
+            .expect_follow = true,
+            .dir_prefix = ".config/",
+            .expected_path = ".config/target",
+        },
+    };
+
+    for (cases) |case| {
+        var followed = false;
+        var sh: Shell = .{
+            .host = .{
+                .expected_path = case.expected_path,
+                .follow_kind = case.follow_kind,
+                .follow_called = &followed,
+            },
+        };
+        const is_directory = try pathCandidateIsDirectory(
+            std.testing.allocator,
+            &sh,
+            case.dir_prefix,
+            case.expand_tilde,
+            case.home,
+            .{ .name = case.name, .kind = case.kind },
+        );
+        try std.testing.expectEqual(case.expect_directory, is_directory);
+        try std.testing.expectEqual(case.expect_follow, followed);
+    }
 }

--- a/src/extensions/rush.zig
+++ b/src/extensions/rush.zig
@@ -1392,7 +1392,14 @@ fn appendPathCompletionCandidates(context: *CompletionContext, sh: anytype, dire
     for (entries.entries) |entry| {
         if (entry.name.len == 0 or std.mem.eql(u8, entry.name, ".") or std.mem.eql(u8, entry.name, "..")) continue;
         if (!include_hidden and entry.name[0] == '.') continue;
-        const is_directory = entry.kind == .directory;
+        const is_directory = try completion_path.pathCandidateIsDirectory(
+            context.allocator,
+            sh,
+            dir_prefix,
+            context.expand_leading_tilde,
+            shellValue(sh, "HOME"),
+            entry,
+        );
         if (directories_only and !is_directory) continue;
         const value = if (is_directory)
             try std.fmt.allocPrint(context.allocator, "{s}{s}/", .{ dir_prefix, entry.name })
@@ -1421,6 +1428,10 @@ test "rush_complete path provider leaves case-insensitive filtering to the match
             errdefer allocator.free(entries);
             entries[0] = .{ .name = try allocator.dupe(u8, "AGENTS.md"), .kind = .file };
             return .{ .allocator = allocator, .entries = entries };
+        }
+
+        pub fn fileTestStatusZ(_: *Self, _: [:0]const u8, _: bool) ?host.FileStatus {
+            unreachable;
         }
     };
     const TestShell = struct {
@@ -1475,6 +1486,10 @@ test "rush_complete path provider expands only an eligible leading tilde" {
             try std.testing.expectEqualStrings(self.expected_path, path);
             return .{ .allocator = allocator, .entries = try allocator.alloc(host.DirectoryEntry, 0) };
         }
+
+        pub fn fileTestStatusZ(_: *Self, _: [:0]const u8, _: bool) ?host.FileStatus {
+            unreachable;
+        }
     };
     const TestShell = struct {
         host: TestHost,
@@ -1508,6 +1523,102 @@ test "rush_complete path provider expands only an eligible leading tilde" {
 
         try appendPathCompletionCandidates(&context, &sh, false);
     }
+}
+
+test "rush_complete path provider follows symlink directories" {
+    const TestState = struct {
+        const Self = @This();
+
+        fn getVariable(_: Self, _: []const u8) ?shell.state.Variable {
+            return null;
+        }
+    };
+    const TestHost = struct {
+        const Self = @This();
+
+        pub fn listDir(_: *Self, allocator: std.mem.Allocator, path: []const u8) !host.ListDirResult {
+            try std.testing.expectEqualStrings(".", path);
+            const entries = try allocator.alloc(host.DirectoryEntry, 4);
+            errdefer allocator.free(entries);
+            entries[0] = .{ .name = try allocator.dupe(u8, "linkdir"), .kind = .symlink };
+            entries[1] = .{ .name = try allocator.dupe(u8, "linkfile"), .kind = .symlink };
+            entries[2] = .{ .name = try allocator.dupe(u8, "broken"), .kind = .symlink };
+            entries[3] = .{ .name = try allocator.dupe(u8, "realdir"), .kind = .directory };
+            return .{ .allocator = allocator, .entries = entries };
+        }
+
+        pub fn fileTestStatusZ(_: *Self, path: [:0]const u8, follow_symlinks: bool) ?host.FileStatus {
+            std.testing.expect(follow_symlinks) catch unreachable;
+            if (std.mem.eql(u8, path, "linkdir")) return .{ .kind = .directory };
+            if (std.mem.eql(u8, path, "linkfile")) return .{ .kind = .file };
+            return null;
+        }
+    };
+    const TestShell = struct {
+        host: TestHost,
+        state: TestState,
+        env: []const [*:0]const u8 = &.{},
+    };
+
+    var files_context: CompletionContext = .init(
+        std.testing.allocator,
+        "link",
+        false,
+        0,
+        "link".len,
+        0,
+        false,
+        "item",
+        &.{},
+        &.{},
+    );
+    defer files_context.deinit();
+    var sh: TestShell = .{ .host = .{}, .state = .{} };
+    try appendPathCompletionCandidates(&files_context, &sh, false);
+    const file_candidates = try files_context.takeCandidates();
+    defer completion.freeCandidates(std.testing.allocator, file_candidates);
+
+    try std.testing.expectEqual(@as(usize, 4), file_candidates.len);
+    try expectPathCandidate(file_candidates, "linkdir/", .directory, false);
+    try expectPathCandidate(file_candidates, "linkfile", .file, true);
+    try expectPathCandidate(file_candidates, "broken", .file, true);
+    try expectPathCandidate(file_candidates, "realdir/", .directory, false);
+
+    var dirs_context: CompletionContext = .init(
+        std.testing.allocator,
+        "link",
+        false,
+        0,
+        "link".len,
+        0,
+        false,
+        "item",
+        &.{},
+        &.{},
+    );
+    defer dirs_context.deinit();
+    try appendPathCompletionCandidates(&dirs_context, &sh, true);
+    const dir_candidates = try dirs_context.takeCandidates();
+    defer completion.freeCandidates(std.testing.allocator, dir_candidates);
+
+    try std.testing.expectEqual(@as(usize, 2), dir_candidates.len);
+    try expectPathCandidate(dir_candidates, "linkdir/", .directory, false);
+    try expectPathCandidate(dir_candidates, "realdir/", .directory, false);
+}
+
+fn expectPathCandidate(
+    candidates: []const completion.Candidate,
+    value: []const u8,
+    kind: completion.Kind,
+    append_space: bool,
+) !void {
+    for (candidates) |candidate| {
+        if (!std.mem.eql(u8, candidate.value, value)) continue;
+        try std.testing.expectEqual(kind, candidate.kind);
+        try std.testing.expectEqual(append_space, candidate.append_space);
+        return;
+    }
+    return error.ExpectedPathCandidate;
 }
 
 fn appendCompletionCandidate(

--- a/src/shell/eval.zig
+++ b/src/shell/eval.zig
@@ -2065,19 +2065,24 @@ fn changeDirectoryBuiltin(
     const allocator = shell.scratchAllocator();
     const old_pwd = try currentLogicalDir(shell);
     var target = initial_target;
-    shell.host.changeDir(target) catch |err| {
+    // POSIX cd -L canonicalizes curpath, then chdir()s that path. Using the
+    // original operand would make `cd ..` follow the physical parent of a
+    // symlink while $PWD moved to the logical parent.
+    var new_pwd = if (physical) target else try logicalPath(allocator, old_pwd, target);
+    shell.host.changeDir(new_pwd) catch |err| {
         target = if (allow_suggestion)
             try cdSuggestionRecoveryTarget(shell, builtin_name, target, err) orelse return .{ .status = 1 }
         else {
             try writeCdFailureDiagnostic(shell, builtin_name, target, err, null, .line);
             return .{ .status = 1 };
         };
-        shell.host.changeDir(target) catch |recovery_err| {
+        new_pwd = if (physical) target else try logicalPath(allocator, old_pwd, target);
+        shell.host.changeDir(new_pwd) catch |recovery_err| {
             try writeCdFailureDiagnostic(shell, builtin_name, target, recovery_err, null, .line);
             return .{ .status = 1 };
         };
     };
-    const new_pwd = if (physical) try shell.host.currentDir(allocator) else try logicalPath(allocator, old_pwd, target);
+    if (physical) new_pwd = try shell.host.currentDir(allocator);
     shell.state.putVariable(.{ .name = "OLDPWD", .value = old_pwd, .exported = exportedFlag(shell, "OLDPWD") }) catch {
         return .{ .status = 1 };
     };
@@ -3576,6 +3581,67 @@ fn normalizeAbsolutePath(allocator: std.mem.Allocator, path: []const u8) ![]cons
         cursor += component.len;
     }
     return normalized;
+}
+
+test "logical cd chdirs the canonicalized path rather than the operand" {
+    const TestHost = struct {
+        const Self = @This();
+
+        last_target: []const u8 = "",
+        stderr: std.ArrayList(u8) = .empty,
+
+        fn deinit(self: *Self) void {
+            self.stderr.deinit(std.testing.allocator);
+            self.* = undefined;
+        }
+
+        fn currentDir(_: *Self, allocator: std.mem.Allocator) ![]const u8 {
+            return allocator.dupe(u8, "/logical/link");
+        }
+
+        fn changeDir(self: *Self, target: []const u8) !void {
+            self.last_target = target;
+        }
+
+        fn currentParentProcessId(_: *Self) host_mod.Pid {
+            return 1;
+        }
+
+        fn writeAll(self: *Self, fd: host_mod.Fd, bytes: []const u8) !void {
+            if (fd == .stderr) try self.stderr.appendSlice(std.testing.allocator, bytes);
+        }
+    };
+    const TestShell = struct {
+        const Self = @This();
+
+        host: TestHost,
+        state: state_mod.State,
+        env: []const [*:0]const u8 = &.{},
+        scratch: std.mem.Allocator,
+
+        fn scratchAllocator(self: *Self) std.mem.Allocator {
+            return self.scratch;
+        }
+    };
+
+    var scratch = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer scratch.deinit();
+    var shell: TestShell = .{
+        .host = .{},
+        .state = state_mod.State.init(std.testing.allocator, .{}),
+        .scratch = scratch.allocator(),
+    };
+    defer shell.host.deinit();
+    defer shell.state.deinit();
+    try shell.state.putVariable(.{ .name = "PWD", .value = "/logical/link", .exported = true });
+
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 0),
+        (try changeDirectoryBuiltin(&shell, "cd", "..", false, false, false)).status,
+    );
+    try std.testing.expectEqualStrings("/logical", shell.host.last_target);
+    try std.testing.expectEqualStrings("/logical", shell.state.getVariable("PWD").?.value);
+    try std.testing.expectEqualStrings("/logical/link", shell.state.getVariable("OLDPWD").?.value);
 }
 
 fn staticDeclarationBuiltinName(shell: anytype, word: ast.Word) !?builtin.Id {

--- a/src/shell/eval.zig
+++ b/src/shell/eval.zig
@@ -2068,7 +2068,10 @@ fn changeDirectoryBuiltin(
     // POSIX cd -L canonicalizes curpath, then chdir()s that path. Using the
     // original operand would make `cd ..` follow the physical parent of a
     // symlink while $PWD moved to the logical parent.
-    var new_pwd = if (physical) target else try logicalPath(allocator, old_pwd, target);
+    var new_pwd = if (physical)
+        target
+    else
+        try logicalCdPath(shell, builtin_name, old_pwd, target) orelse return .{ .status = 1 };
     shell.host.changeDir(new_pwd) catch |err| {
         target = if (allow_suggestion)
             try cdSuggestionRecoveryTarget(shell, builtin_name, target, err) orelse return .{ .status = 1 }
@@ -2076,7 +2079,10 @@ fn changeDirectoryBuiltin(
             try writeCdFailureDiagnostic(shell, builtin_name, target, err, null, .line);
             return .{ .status = 1 };
         };
-        new_pwd = if (physical) target else try logicalPath(allocator, old_pwd, target);
+        new_pwd = if (physical)
+            target
+        else
+            try logicalCdPath(shell, builtin_name, old_pwd, target) orelse return .{ .status = 1 };
         shell.host.changeDir(new_pwd) catch |recovery_err| {
             try writeCdFailureDiagnostic(shell, builtin_name, target, recovery_err, null, .line);
             return .{ .status = 1 };
@@ -3547,34 +3553,55 @@ fn startsWithDotPathComponent(path: []const u8) bool {
         std.mem.startsWith(u8, path, "./") or std.mem.startsWith(u8, path, "../");
 }
 
-fn logicalPath(allocator: std.mem.Allocator, old_pwd: []const u8, target: []const u8) ![]const u8 {
+fn logicalCdPath(shell: anytype, builtin_name: []const u8, old_pwd: []const u8, target: []const u8) !?[]const u8 {
+    return logicalPath(shell, old_pwd, target) catch |err| switch (err) {
+        error.NotDir => {
+            try writeCdFailureDiagnostic(shell, builtin_name, target, err, null, .line);
+            return null;
+        },
+        else => return err,
+    };
+}
+
+fn logicalPath(shell: anytype, old_pwd: []const u8, target: []const u8) ![]const u8 {
+    const allocator = shell.scratchAllocator();
     var combined: []const u8 = target;
     if (target.len == 0 or target[0] != '/') {
         combined = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ old_pwd, target });
     }
-    return normalizeAbsolutePath(allocator, combined);
+    return normalizeAbsolutePath(shell, combined);
 }
 
-fn normalizeAbsolutePath(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
+fn normalizeAbsolutePath(shell: anytype, path: []const u8) ![]const u8 {
     // ziglint-ignore: Z016 compound assert documents a single invariant; preserve readability
     std.debug.assert(path.len != 0 and path[0] == '/');
+    const allocator = shell.scratchAllocator();
     var components: std.ArrayList([]const u8) = .empty;
     var iterator = std.mem.splitScalar(u8, path, '/');
     while (iterator.next()) |component| {
         if (component.len == 0 or std.mem.eql(u8, component, ".")) continue;
         if (std.mem.eql(u8, component, "..")) {
-            if (components.items.len != 0) components.items.len -= 1;
+            if (components.items.len != 0) {
+                const preceding_path = try absolutePathFromComponents(allocator, components.items);
+                const status = try fileStatus(shell, preceding_path, true) orelse return error.NotDir;
+                if (status.kind != .directory) return error.NotDir;
+                components.items.len -= 1;
+            }
             continue;
         }
         try components.append(allocator, component);
     }
-    if (components.items.len == 0) return allocator.dupe(u8, "/");
+    return absolutePathFromComponents(allocator, components.items);
+}
+
+fn absolutePathFromComponents(allocator: std.mem.Allocator, components: []const []const u8) ![]const u8 {
+    if (components.len == 0) return allocator.dupe(u8, "/");
 
     var total_len: usize = 0;
-    for (components.items) |component| total_len += component.len + 1;
+    for (components) |component| total_len += component.len + 1;
     const normalized = try allocator.alloc(u8, total_len);
     var cursor: usize = 0;
-    for (components.items) |component| {
+    for (components) |component| {
         normalized[cursor] = '/';
         cursor += 1;
         @memcpy(normalized[cursor..][0..component.len], component);
@@ -3583,7 +3610,7 @@ fn normalizeAbsolutePath(allocator: std.mem.Allocator, path: []const u8) ![]cons
     return normalized;
 }
 
-test "logical cd chdirs the canonicalized path rather than the operand" {
+test "logical cd validates and chdirs the canonicalized path" {
     const TestHost = struct {
         const Self = @This();
 
@@ -3601,6 +3628,13 @@ test "logical cd chdirs the canonicalized path rather than the operand" {
 
         fn changeDir(self: *Self, target: []const u8) !void {
             self.last_target = target;
+        }
+
+        fn fileTestStatusZ(_: *Self, path: [:0]const u8, follow_symlinks: bool) ?host_mod.FileStatus {
+            std.testing.expect(follow_symlinks) catch unreachable;
+            if (std.mem.eql(u8, path, "/logical/link")) return .{ .kind = .directory };
+            if (std.mem.eql(u8, path, "/logical/file")) return .{ .kind = .file };
+            return null;
         }
 
         fn currentParentProcessId(_: *Self) host_mod.Pid {
@@ -3642,6 +3676,16 @@ test "logical cd chdirs the canonicalized path rather than the operand" {
     try std.testing.expectEqualStrings("/logical", shell.host.last_target);
     try std.testing.expectEqualStrings("/logical", shell.state.getVariable("PWD").?.value);
     try std.testing.expectEqualStrings("/logical/link", shell.state.getVariable("OLDPWD").?.value);
+
+    try shell.state.putVariable(.{ .name = "PWD", .value = "/logical/file", .exported = true });
+    shell.host.last_target = "";
+    try std.testing.expectEqual(
+        @as(result.ExitStatus, 1),
+        (try changeDirectoryBuiltin(&shell, "cd", "..", false, false, false)).status,
+    );
+    try std.testing.expectEqualStrings("", shell.host.last_target);
+    try std.testing.expectEqualStrings("/logical/file", shell.state.getVariable("PWD").?.value);
+    try std.testing.expectEqualStrings("cd: ..: not a directory\n", shell.host.stderr.items);
 }
 
 fn staticDeclarationBuiltinName(shell: anytype, word: ast.Word) !?builtin.Id {
@@ -8893,6 +8937,10 @@ test "z builtin jumps through directory history" {
         fn changeDir(self: *Self, target: []const u8) !void {
             if (!std.mem.eql(u8, target, "/repo/project")) return error.FileNotFound;
             self.cwd = "/repo/project";
+        }
+
+        fn fileTestStatusZ(_: *Self, _: [:0]const u8, _: bool) ?host_mod.FileStatus {
+            unreachable;
         }
 
         fn currentParentProcessId(_: *Self) host_mod.Pid {

--- a/tests/posix/builtins.zon
+++ b/tests/posix/builtins.zon
@@ -184,6 +184,23 @@
             .status = 0,
         },
         .{
+            .name = "cd -L leaves a symlink through the logical parent",
+            .script =
+            \\mkdir real logical
+            \\ln -s "$PWD/real" logical/link
+            \\cd logical/link
+            \\cd ..
+            \\physical=$(pwd -P)
+            \\printf '<%s>:<%s>\n' "${PWD##*/}" "${physical##*/}"
+            ,
+            .stdout =
+            \\<logical>:<logical>
+            \\
+            ,
+            .stderr = "",
+            .status = 0,
+        },
+        .{
             .name = "read with -r preserves backslash characters",
             .script =
             \\printf 'a b\\c\n' | { read -r first rest; printf '<%s>:<%s>\n' "$first" "$rest"; }

--- a/tests/posix/builtins.zon
+++ b/tests/posix/builtins.zon
@@ -201,6 +201,23 @@
             .status = 0,
         },
         .{
+            .name = "cd -L rejects a non-directory component before dot-dot",
+            .script =
+            \\: >file
+            \\before=$PWD
+            \\cd file/.. 2>/dev/null
+            \\status=$?
+            \\test "$PWD" = "$before"
+            \\printf '<%s>:<%s>\n' "$status" "$?"
+            ,
+            .stdout =
+            \\<1>:<0>
+            \\
+            ,
+            .stderr = "",
+            .status = 0,
+        },
+        .{
             .name = "read with -r preserves backslash characters",
             .script =
             \\printf 'a b\\c\n' | { read -r first rest; printf '<%s>:<%s>\n' "$first" "$rest"; }


### PR DESCRIPTION
Filename completion treated a directory symlink as a file. Tab on cd `.config/ru` would not suggest/auto-complete `./config/rush` if it was a symlink targeting a directory.

rush_complete files / directories used `entry.kind == .directory`. A dirent of type symlink never followed the target. Builtin path completion already followed symlink and unknown dirents; that check is now shared.

A second bug showed up after using those completions. POSIX `cd -L` (the default) must canonicalize `curpath`, then `chdir()` that path. Rush updated `$PWD` logically but still `chdir()`’d the original operand.

```
~/.config/rush -> /home/hsp/code/dotfiles/arch/config/rush

cd ~/.config/rush
# $PWD = ~/.config/rush
# kernel cwd = .../dotfiles/arch/config/rush

cd ..
# $PWD = ~/.config          (logical parent)
# kernel cwd = .../config   (physical parent)
```

The prompt said one directory; the process was in another.

Logical cd now chdir()s the canonicalized path. `cd ..` from a symlink directory goes to `$PWD/..`, not "..". This matches the behavior of bash (symlink dir is transparent) versus zshell which just follows the symlink if navigating into a symlinked directory.

Examples after the fix:

- nvim linkdir<Tab> → nvim linkdir/ with the cursor ready for another component
- cd linkdir<Tab> includes the symlink and does not append a space
- cat linkfile<Tab> still completes as a file (space, no slash)
- broken/circular links stay file candidates
- cd logical/link; cd .. leaves both $PWD and the kernel cwd in logical



https://ampcode.com/threads/T-01a0455d-1476-77bd-bdce-4185fde804e6