### PR TITLE
deps: update Vaxis for malformed color reports

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .vaxis = .{
-            .url = "git+https://github.com/rockorager/libvaxis.git#a367b89da09bfe5e1b628501940de5b4f858f5f3",
-            .hash = "vaxis-0.6.0-BWNV_HHwCQB451KS7A8SMykALblPmGwHnzSfiJHjN3_9",
+            .url = "git+https://github.com/rockorager/libvaxis.git#a12e9c3046247b6e2e877bf1dcb3806929ecb01a",
+            .hash = "vaxis-0.6.0-BWNV_EojCgAHV2Lvn5hO22DPkmB1YRlswBIvavDqmP8K",
         },
         .sqlite = .{
             .url = "https://www.sqlite.org/2026/sqlite-amalgamation-3530200.zip",


### PR DESCRIPTION
I noticed konsole exiting immediately when using rush as the shell. If I start with bash and then run rush, I see:
```
[hsp@fwd rush]$ rush
~/code/rush ●  rush: editor error: InvalidColorSpec
                                                   [hsp@fwd rush]$ 
```

Looks like libvaxis resolved this: https://github.com/rockorager/libvaxis/commit/a12e9c3046247b6e2e877bf1dcb3806929ecb01a

This updates the libvaxis dep to that commit (wasn't sure if we prefered this to bumping to latest, decided to be conservative).