### PR TITLE
shell: preserve aliases while autoloading functions

### DIFF
--- a/src/function_autoload.zig
+++ b/src/function_autoload.zig
@@ -317,6 +317,52 @@ test "autoload sources dotted function into current shell and hides load output"
     try std.testing.expectEqualStrings("redefined", redefined_output);
 }
 
+test "autoload protects function definition from same-name alias" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    const root = try std.fmt.allocPrint(allocator, "rush-test-autoload-alias-{d}", .{std.c.getpid()});
+    defer allocator.free(root);
+    // ziglint-ignore: Z026 intentional best-effort cleanup; preserve behavior
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    const functions_dir = try std.fs.path.join(allocator, &.{ root, "rush", "functions" });
+    defer allocator.free(functions_dir);
+    try std.Io.Dir.cwd().createDirPath(io, functions_dir);
+
+    const name = "rush_alias_autoload_test_function";
+    const function_path = try std.fs.path.join(allocator, &.{ functions_dir, name ++ ".rush" });
+    defer allocator.free(function_path);
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = function_path,
+        .data = name ++ "(){ printf '<%s>\\n' \"$1\"; }\n",
+    });
+
+    var sh = TestRushShell.init(allocator, .{}, .{ .state = .{ .expand_aliases = true } });
+    defer sh.deinit();
+    sh.setFunctionAutoload(testAutoload);
+    try sh.state.putVariable(.{ .name = "XDG_CONFIG_HOME", .value = root });
+    try sh.state.putAlias(.{ .name = name, .value = name ++ " prefixed" });
+
+    const out_path = try std.fs.path.join(allocator, &.{ root, "out.txt" });
+    defer allocator.free(out_path);
+    const command = try std.fmt.allocPrint(allocator, "{s} > {s}", .{ name, out_path });
+    defer allocator.free(command);
+    const evaluated = try sh.evalSource(.{
+        .id = 1,
+        .kind = .command_string,
+        .name = "test",
+        .text = command,
+    });
+    try std.testing.expectEqual(@as(shell.result.ExitStatus, 0), evaluated.status);
+
+    const output = try std.Io.Dir.cwd().readFileAlloc(io, out_path, allocator, .limited(1024));
+    defer allocator.free(output);
+    try std.testing.expectEqualStrings("<prefixed>\n", output);
+    try std.testing.expect(sh.state.getFunction(name) != null);
+    try std.testing.expectEqualStrings(name ++ " prefixed", sh.state.getAlias(name).?.value);
+}
+
 test "autoload caches misses until function is explicitly defined" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;

--- a/src/shell/lexer.zig
+++ b/src/shell/lexer.zig
@@ -68,6 +68,16 @@ pub const AliasLexResult = struct {
     tokens: []const token.Token,
 };
 
+/// Context supplied by evaluator-owned parsing paths that require a narrow
+/// exception to ordinary alias substitution.
+pub const AliasOptions = struct {
+    /// Protects the selected autoload function's declaration while its source
+    /// is parsed. Ordinary shell input must leave this unset: alias eligibility
+    /// is determined without considering tokens that follow the candidate. The
+    /// name is borrowed for the duration of the lexing call.
+    autoload_function_name: ?[]const u8 = null,
+};
+
 /// Text introduced by an alias remains marked until recursive alias
 /// substitution finishes, so that alias cannot expand itself again while
 /// independent occurrences of the same name remain eligible.
@@ -100,6 +110,20 @@ pub fn lexWithAliasesSource(
     src: source_mod.Source,
     shell_state: state_mod.State,
 ) std.mem.Allocator.Error!AliasLexResult {
+    return lexWithAliasesSourceOptions(allocator, src, shell_state, .{});
+}
+
+/// Matches `lexWithAliasesSource` ownership and lifetimes while allowing the
+/// evaluator to identify an autoload function declaration that must retain its
+/// requested name. Do not set the option for ordinary shell input.
+pub fn lexWithAliasesSourceOptions(
+    allocator: std.mem.Allocator,
+    src: source_mod.Source,
+    shell_state: state_mod.State,
+    options: AliasOptions,
+) std.mem.Allocator.Error!AliasLexResult {
+    if (options.autoload_function_name) |name| std.debug.assert(name.len != 0);
+
     var current_src = src;
     var active_alias_spans: []const ActiveAliasSpan = &.{};
     while (true) {
@@ -110,6 +134,7 @@ pub fn lexWithAliasesSource(
             tokens,
             shell_state,
             active_alias_spans,
+            options,
         ) orelse return .{
             .source = current_src,
             .tokens = tokens,
@@ -125,6 +150,7 @@ fn aliasExpandedSource(
     tokens: []const token.Token,
     shell_state: state_mod.State,
     active_alias_spans: []const ActiveAliasSpan,
+    options: AliasOptions,
 ) std.mem.Allocator.Error!?AliasExpansion {
     if (shell_state.aliases.count() == 0) return null;
     if (!aliasesEnabled(shell_state)) return null;
@@ -138,7 +164,7 @@ fn aliasExpandedSource(
     var command_position = true;
     var skip_redirection_target = false;
 
-    for (tokens) |tok| {
+    for (tokens, 0..) |tok, index| {
         if (tok.kind == .eof) break;
         try appendAliasSourceSlice(
             allocator,
@@ -179,7 +205,9 @@ fn aliasExpandedSource(
                 );
                 continue;
             }
-            if (command_position and !tok.quoted and !token.isAssignmentWord(tok.text)) {
+            if (command_position and !tok.quoted and !token.isAssignmentWord(tok.text) and
+                !isAutoloadFunctionDefinitionName(tokens, index, options.autoload_function_name))
+            {
                 if (shell_state.getAlias(tok.text)) |alias| {
                     if (!aliasIsActive(active_alias_spans, tok.span.start, tok.span.end, alias.name)) {
                         const replacement_start = output.items.len;
@@ -337,6 +365,18 @@ fn aliasIsActive(
             std.mem.eql(u8, span.name, name)) return true;
     }
     return false;
+}
+
+fn isAutoloadFunctionDefinitionName(
+    tokens: []const token.Token,
+    index: usize,
+    autoload_function_name: ?[]const u8,
+) bool {
+    const name = autoload_function_name orelse return false;
+    return std.mem.eql(u8, tokens[index].text, name) and
+        index + 2 < tokens.len and
+        tokens[index + 1].kind == .left_paren and
+        tokens[index + 2].kind == .right_paren;
 }
 
 pub fn aliasesEnabled(shell_state: state_mod.State) bool {
@@ -1768,4 +1808,42 @@ test "alias substitution copies here-document bodies verbatim" {
 
     // The command-position `hi` after the body expands; the body line does not.
     try std.testing.expectEqualStrings("cat <<E\nhi\nE\nprintf hi\n", lexed.source.text);
+}
+
+test "self-referential alias expands only once" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var shell_state = state_mod.State.init(std.testing.allocator, .{ .mode = .posix });
+    defer shell_state.deinit();
+    try shell_state.putAlias(.{ .name = "ls", .value = "ls -lhv --color --group-directories-first" });
+
+    const src: source_mod.Source = .{
+        .id = 1,
+        .kind = .script_file,
+        .name = "test",
+        .text = "ls\n",
+    };
+    const lexed = try lexWithAliasesSource(allocator, src, shell_state);
+
+    try std.testing.expectEqualStrings("ls -lhv --color --group-directories-first\n", lexed.source.text);
+}
+
+test "autoload function definition name bypasses alias substitution" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var shell_state = state_mod.State.init(std.testing.allocator, .{ .interactive = true });
+    defer shell_state.deinit();
+    try shell_state.putAlias(.{ .name = "ls", .value = "ls -lhv --color --group-directories-first" });
+
+    const src: source_mod.Source = .{
+        .id = 1,
+        .kind = .sourced_file,
+        .name = "test",
+        .text = "ls() { printf hi; }\n",
+    };
+    const lexed = try lexWithAliasesSourceOptions(allocator, src, shell_state, .{ .autoload_function_name = "ls" });
+
+    try std.testing.expectEqualStrings(src.text, lexed.source.text);
 }

--- a/src/shell/shell_factory.zig
+++ b/src/shell/shell_factory.zig
@@ -299,7 +299,9 @@ pub fn ShellWithBuiltins(comptime Host: type, comptime builtin_registry: builtin
             const chunk_src: source.Source = .{ .id = src.id, .kind = src.kind, .name = src.name, .text = text };
 
             const ast_allocator = self.astAllocator();
-            const lexed = try lexer.lexWithAliasesSource(ast_allocator, chunk_src, self.state);
+            const lexed = try lexer.lexWithAliasesSourceOptions(ast_allocator, chunk_src, self.state, .{
+                .autoload_function_name = self.autoloading_function,
+            });
             const program = try parser.parseWithAliasesAndOptions(
                 ast_allocator,
                 lexed.source,

--- a/tests/bash/aliases.zon
+++ b/tests/bash/aliases.zon
@@ -65,5 +65,20 @@
             .stderr = "",
             .status = 0,
         },
+        .{
+            .name = "expand_aliases substitutes function definition names",
+            .script =
+            \\shopt -s expand_aliases
+            \\alias f=g
+            \\f() { printf '%s\n' function; }
+            \\f
+            ,
+            .stdout =
+            \\function
+            \\
+            ,
+            .stderr = "",
+            .status = 0,
+        },
     },
 }

--- a/tests/posix/token_recognition.zon
+++ b/tests/posix/token_recognition.zon
@@ -348,6 +348,34 @@
             .status = 0,
         },
         .{
+            .name = "alias substitution ignores following function definition tokens",
+            .script =
+            \\alias f=g
+            \\f() { printf '%s\n' function; }
+            \\f
+            ,
+            .stdout =
+            \\function
+            \\
+            ,
+            .stderr = "",
+            .status = 0,
+        },
+        .{
+            .name = "non-name alias can introduce a function definition name",
+            .script =
+            \\alias x-y=f
+            \\x-y() { printf '%s\n' function; }
+            \\f
+            ,
+            .stdout =
+            \\function
+            \\
+            ,
+            .stderr = "",
+            .status = 0,
+        },
+        .{
             .name = "function bodies capture aliases at definition time",
             .script =
             \\alias hit='printf "%s\n" alias'


### PR DESCRIPTION
I want to use a self-referential `alias` instead of an `abbr` so that I don't see all the flags expanded. Trying to do this currently fails:
```
# .config/rush/config.rush
alias ls='ls -lhv --color --group-directories-first'
```
```
~/code/rush ●  ls
1: syntax error: unexpected end of input
```

A self-referential alias broke when its matching helper was autoloaded: Rush rewrote the helper’s ls() declaration, causing a syntax error.

The fix protects only that autoloaded declaration. Normal alias expansion is unchanged.