### PR TITLE
history: fetch Ctrl-R results one page at a time

### DIFF
--- a/src/editor/driver.zig
+++ b/src/editor/driver.zig
@@ -1060,6 +1060,9 @@ fn resolveHistorySearch(
     filters: line_editor.HistorySearchFilters,
     before: ?i64,
 ) ![]line_editor.HistoryView.HistoryEntry {
+    if (history.search_page) |search_page| {
+        return resolveHistorySearchPage(allocator, search_page, context, query, filters, before);
+    }
     const search = history.search orelse return &.{};
     var matches: std.ArrayList(line_editor.HistoryView.HistoryEntry) = .empty;
     errdefer {
@@ -1081,6 +1084,9 @@ fn resolveHistorySearchNext(
     filters: line_editor.HistorySearchFilters,
     after: ?i64,
 ) ![]line_editor.HistoryView.HistoryEntry {
+    if (history.search_next_page) |search_page| {
+        return resolveHistorySearchPage(allocator, search_page, context, query, filters, after);
+    }
     const search_next = history.search_next orelse
         return resolveHistorySearch(allocator, history, context, query, filters, null);
     var matches: std.ArrayList(line_editor.HistoryView.HistoryEntry) = .empty;
@@ -1093,6 +1099,35 @@ fn resolveHistorySearchNext(
         try appendHistorySearchEntries(allocator, &matches, search_next, context, query, filters, null);
     }
     return matches.toOwnedSlice(allocator);
+}
+
+const history_search_page_size = 20;
+
+const HistorySearchPageCallback = *const fn (
+    *anyopaque,
+    std.mem.Allocator,
+    []const u8,
+    line_editor.HistorySearchFilters,
+    ?i64,
+    usize,
+) anyerror![]line_editor.HistoryView.HistoryEntry;
+
+fn resolveHistorySearchPage(
+    allocator: std.mem.Allocator,
+    callback: HistorySearchPageCallback,
+    context: *anyopaque,
+    query: []const u8,
+    filters: line_editor.HistorySearchFilters,
+    cursor: ?i64,
+) ![]line_editor.HistoryView.HistoryEntry {
+    var matches = try callback(context, allocator, query, filters, cursor, history_search_page_size);
+    std.debug.assert(matches.len <= history_search_page_size);
+    if (matches.len != 0 or cursor == null) return matches;
+
+    allocator.free(matches);
+    matches = try callback(context, allocator, query, filters, null, history_search_page_size);
+    std.debug.assert(matches.len <= history_search_page_size);
+    return matches;
 }
 
 const HistorySearchCallback = *const fn (
@@ -1113,7 +1148,7 @@ fn appendHistorySearchEntries(
     start_cursor: ?i64,
 ) !void {
     var cursor = start_cursor;
-    while (matches.items.len < 20) {
+    while (matches.items.len < history_search_page_size) {
         const entry = try callback(context, allocator, query, filters, cursor) orelse break;
         cursor = entry.id;
         try matches.append(allocator, entry);
@@ -1318,6 +1353,55 @@ fn appendOscText(writer: *std.Io.Writer, text: []const u8) !void {
         0x00...0x1f, 0x7f => try writer.writeByte(' '),
         else => try writer.writeByte(byte),
     };
+}
+
+const TestHistoryPage = struct {
+    calls: usize = 0,
+
+    fn search(
+        context: *anyopaque,
+        allocator: std.mem.Allocator, // ziglint-ignore: Z023 callback signature
+        query: []const u8,
+        filters: line_editor.HistorySearchFilters,
+        cursor: ?i64,
+        limit: usize,
+    ) ![]line_editor.HistoryView.HistoryEntry {
+        const provider: *TestHistoryPage = @ptrCast(@alignCast(context));
+        provider.calls += 1;
+        try std.testing.expectEqualStrings(" ", query);
+        try std.testing.expectEqual(@as(line_editor.HistorySearchFilters, .{}), filters);
+        try std.testing.expectEqual(@as(?i64, null), cursor);
+        try std.testing.expectEqual(history_search_page_size, limit);
+
+        const entries = try allocator.alloc(line_editor.HistoryView.HistoryEntry, limit);
+        errdefer allocator.free(entries);
+        var initialized: usize = 0;
+        errdefer for (entries[0..initialized]) |entry| entry.deinit(allocator);
+        for (entries, 0..) |*entry, index| {
+            entry.* = .{
+                .id = @intCast(index + 1),
+                .text = try std.fmt.allocPrint(allocator, "history {d}", .{index}),
+            };
+            initialized += 1;
+        }
+        return entries;
+    }
+};
+
+test "history page callback resolves a search in one provider call" {
+    var provider: TestHistoryPage = .{};
+    const result = try resolveHistoryRequest(std.testing.allocator, .{
+        .context = &provider,
+        .search_page = TestHistoryPage.search,
+    }, .{ .search = .{ .query = " ", .filters = .{}, .before = null } });
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), provider.calls);
+    const entries = switch (result) {
+        .entries => |items| items,
+        .entry => return error.TestExpectedHistoryPage,
+    };
+    try std.testing.expectEqual(history_search_page_size, entries.len);
 }
 
 fn testExpandAbbreviation(

--- a/src/editor/history.zig
+++ b/src/editor/history.zig
@@ -23,8 +23,8 @@ pub const View = struct {
     entries: []const []const u8 = &.{},
     now: i64 = 0,
     context: ?*anyopaque = null,
-    /// Provider callbacks return allocator-owned `HistoryEntry` values. The
-    /// line session copies `entry.text` before calling `HistoryEntry.deinit`.
+    /// Provider callbacks return entries deeply owned by the supplied
+    /// allocator. Page callbacks allocate both the slice and each entry text.
     previous: ?*const fn (*anyopaque, std.mem.Allocator, []const u8, ?i64) anyerror!?HistoryEntry = null,
     next: ?*const fn (*anyopaque, std.mem.Allocator, []const u8, i64) anyerror!?HistoryEntry = null,
     by_number: ?*const fn (*anyopaque, std.mem.Allocator, usize) anyerror!?HistoryEntry = null,
@@ -42,6 +42,22 @@ pub const View = struct {
         SearchFilters,
         ?i64,
     ) anyerror!?HistoryEntry = null,
+    search_page: ?*const fn (
+        *anyopaque,
+        std.mem.Allocator,
+        []const u8,
+        SearchFilters,
+        ?i64,
+        usize,
+    ) anyerror![]HistoryEntry = null,
+    search_next_page: ?*const fn (
+        *anyopaque,
+        std.mem.Allocator,
+        []const u8,
+        SearchFilters,
+        ?i64,
+        usize,
+    ) anyerror![]HistoryEntry = null,
     suggest: ?*const fn (*anyopaque, std.mem.Allocator, []const u8) anyerror!?HistoryEntry = null,
 };
 

--- a/src/history.zig
+++ b/src/history.zig
@@ -287,6 +287,56 @@ pub const History = struct {
         return queryHistorySearchEntry(allocator, self.db, query, cwd, session_id, filters, after, .next);
     }
 
+    /// Returns up to `limit` deeply owned entries in backward search order.
+    /// `limit` must be greater than zero.
+    pub fn searchPage(
+        self: *History,
+        allocator: std.mem.Allocator,
+        query: []const u8,
+        cwd: []const u8,
+        session_id: []const u8,
+        filters: line_editor.HistorySearchFilters,
+        before: ?i64,
+        limit: usize,
+    ) ![]line_editor.HistoryView.HistoryEntry {
+        return queryHistorySearchEntries(
+            allocator,
+            self.db,
+            query,
+            cwd,
+            session_id,
+            filters,
+            before,
+            limit,
+            .previous,
+        );
+    }
+
+    /// Returns up to `limit` deeply owned entries in forward search order.
+    /// `limit` must be greater than zero.
+    pub fn searchNextPage(
+        self: *History,
+        allocator: std.mem.Allocator,
+        query: []const u8,
+        cwd: []const u8,
+        session_id: []const u8,
+        filters: line_editor.HistorySearchFilters,
+        after: ?i64,
+        limit: usize,
+    ) ![]line_editor.HistoryView.HistoryEntry {
+        return queryHistorySearchEntries(
+            allocator,
+            self.db,
+            query,
+            cwd,
+            session_id,
+            filters,
+            after,
+            limit,
+            .next,
+        );
+    }
+
     pub fn suggestEntry(
         self: *History,
         allocator: std.mem.Allocator,
@@ -340,6 +390,8 @@ pub const InteractiveHistoryService = struct {
             .by_number = numberedHistoryEntry,
             .search = searchHistoryEntry,
             .search_next = searchNextHistoryEntry,
+            .search_page = searchHistoryPage,
+            .search_next_page = searchNextHistoryPage,
             .suggest = suggestHistoryEntry,
         };
     }
@@ -555,6 +607,44 @@ pub const InteractiveHistoryService = struct {
         );
     }
 
+    fn searchPage(
+        self: *InteractiveHistoryService,
+        allocator: std.mem.Allocator,
+        query: []const u8,
+        filters: line_editor.HistorySearchFilters,
+        before: ?i64,
+        limit: usize,
+    ) ![]line_editor.HistoryView.HistoryEntry {
+        return self.history.searchPage(
+            allocator,
+            query,
+            self.history.current_cwd,
+            self.history.session_id,
+            filters,
+            before,
+            limit,
+        );
+    }
+
+    fn searchNextPage(
+        self: *InteractiveHistoryService,
+        allocator: std.mem.Allocator,
+        query: []const u8,
+        filters: line_editor.HistorySearchFilters,
+        after: ?i64,
+        limit: usize,
+    ) ![]line_editor.HistoryView.HistoryEntry {
+        return self.history.searchNextPage(
+            allocator,
+            query,
+            self.history.current_cwd,
+            self.history.session_id,
+            filters,
+            after,
+            limit,
+        );
+    }
+
     fn suggestEntry(
         self: *InteractiveHistoryService,
         allocator: std.mem.Allocator,
@@ -619,6 +709,30 @@ fn searchNextHistoryEntry(
 ) !?line_editor.HistoryView.HistoryEntry {
     const history_service: *InteractiveHistoryService = @ptrCast(@alignCast(context));
     return history_service.searchNextEntry(allocator, query, filters, after);
+}
+
+fn searchHistoryPage(
+    context: *anyopaque,
+    allocator: std.mem.Allocator, // ziglint-ignore: Z023 (callback iface)
+    query: []const u8,
+    filters: line_editor.HistorySearchFilters,
+    before: ?i64,
+    limit: usize,
+) ![]line_editor.HistoryView.HistoryEntry {
+    const history_service: *InteractiveHistoryService = @ptrCast(@alignCast(context));
+    return history_service.searchPage(allocator, query, filters, before, limit);
+}
+
+fn searchNextHistoryPage(
+    context: *anyopaque,
+    allocator: std.mem.Allocator, // ziglint-ignore: Z023 (callback iface)
+    query: []const u8,
+    filters: line_editor.HistorySearchFilters,
+    after: ?i64,
+    limit: usize,
+) ![]line_editor.HistoryView.HistoryEntry {
+    const history_service: *InteractiveHistoryService = @ptrCast(@alignCast(context));
+    return history_service.searchNextPage(allocator, query, filters, after, limit);
 }
 
 fn suggestHistoryEntry(
@@ -1208,17 +1322,55 @@ fn queryHistorySearchEntry(
     cursor: ?i64,
     direction: HistoryDirection,
 ) !?line_editor.HistoryView.HistoryEntry {
+    const entries = try queryHistorySearchEntries(
+        allocator,
+        db,
+        query,
+        cwd,
+        session_id,
+        filters,
+        cursor,
+        1,
+        direction,
+    );
+    defer allocator.free(entries);
+    std.debug.assert(entries.len <= 1);
+    return if (entries.len == 0) null else entries[0];
+}
+
+fn queryHistorySearchEntries(
+    allocator: std.mem.Allocator,
+    db: *sqlite.sqlite3,
+    query: []const u8,
+    cwd: []const u8,
+    session_id: []const u8,
+    filters: line_editor.HistorySearchFilters,
+    cursor: ?i64,
+    limit: usize,
+    direction: HistoryDirection,
+) ![]line_editor.HistoryView.HistoryEntry {
+    std.debug.assert(limit > 0);
     // FTS can only express word-prefix matches, so queries with punctuation
     // (flags, paths, operators) switch to a literal substring match instead
     // of silently dropping the bytes FTS cannot tokenize.
     if (historySearchNeedsSubstring(query)) {
-        return queryHistorySubstringSearchEntry(allocator, db, query, cwd, session_id, filters, cursor, direction);
+        return queryHistorySubstringSearchEntries(
+            allocator,
+            db,
+            query,
+            cwd,
+            session_id,
+            filters,
+            cursor,
+            limit,
+            direction,
+        );
     }
     var fts_query: std.ArrayList(u8) = .empty;
     defer fts_query.deinit(allocator);
     try appendHistoryFtsQuery(allocator, &fts_query, query);
     if (fts_query.items.len == 0) {
-        return queryHistoryListEntry(allocator, db, cwd, session_id, filters, cursor, direction);
+        return queryHistoryListEntries(allocator, db, cwd, session_id, filters, cursor, limit, direction);
     }
 
     var stmt: ?*sqlite.sqlite3_stmt = null;
@@ -1246,7 +1398,7 @@ fn queryHistorySearchEntry(
         \\      )
         \\  )
         \\order by (h.cwd = ?2) desc, h.id desc
-        \\limit 1 offset ?3
+        \\limit ?8 offset ?3
         ,
         .next =>
         \\select h.id, h.command, h.started_at
@@ -1270,7 +1422,7 @@ fn queryHistorySearchEntry(
         \\      )
         \\  )
         \\order by (h.cwd = ?2) asc, h.id asc
-        \\limit 1 offset ?3
+        \\limit ?8 offset ?3
         ,
     };
     try sqliteCheck(sqlite.sqlite3_prepare_v2(db, sql, -1, &stmt, null), db);
@@ -1282,15 +1434,8 @@ fn queryHistorySearchEntry(
     try sqliteCheck(sqlite.sqlite3_bind_int(stmt, 5, @intFromBool(filters.successful)), db);
     try sqliteCheck(sqlite.sqlite3_bind_int(stmt, 6, @intFromBool(filters.session)), db);
     try sqliteCheck(sqlite.sqlite3_bind_text(stmt, 7, session_id.ptr, @intCast(session_id.len), null), db);
-    const rc = sqlite.sqlite3_step(stmt);
-    if (rc == sqlite.SQLITE_DONE) return null;
-    if (rc != sqlite.SQLITE_ROW) try sqliteCheck(rc, db);
-    const command_text = sqlite.sqlite3_column_text(stmt, 1) orelse return null;
-    return .{
-        .id = offset + 1,
-        .text = try allocator.dupe(u8, std.mem.span(command_text)),
-        .when = sqlite.sqlite3_column_int64(stmt, 2),
-    };
+    try sqliteCheck(sqlite.sqlite3_bind_int64(stmt, 8, @intCast(limit)), db);
+    return collectHistorySearchEntries(allocator, db, stmt.?, offset);
 }
 
 fn historySearchNeedsSubstring(query: []const u8) bool {
@@ -1300,7 +1445,7 @@ fn historySearchNeedsSubstring(query: []const u8) bool {
     return false;
 }
 
-fn queryHistorySubstringSearchEntry(
+fn queryHistorySubstringSearchEntries(
     allocator: std.mem.Allocator,
     db: *sqlite.sqlite3,
     query: []const u8,
@@ -1308,8 +1453,9 @@ fn queryHistorySubstringSearchEntry(
     session_id: []const u8,
     filters: line_editor.HistorySearchFilters,
     cursor: ?i64,
+    limit: usize,
     direction: HistoryDirection,
-) !?line_editor.HistoryView.HistoryEntry {
+) ![]line_editor.HistoryView.HistoryEntry {
     var like_pattern: std.ArrayList(u8) = .empty;
     defer like_pattern.deinit(allocator);
     try appendSqlLikeSubstring(allocator, &like_pattern, query);
@@ -1338,7 +1484,7 @@ fn queryHistorySubstringSearchEntry(
         \\      )
         \\  )
         \\order by (h.cwd = ?2) desc, h.id desc
-        \\limit 1 offset ?3
+        \\limit ?8 offset ?3
         ,
         .next =>
         \\select h.id, h.command, h.started_at
@@ -1361,7 +1507,7 @@ fn queryHistorySubstringSearchEntry(
         \\      )
         \\  )
         \\order by (h.cwd = ?2) asc, h.id asc
-        \\limit 1 offset ?3
+        \\limit ?8 offset ?3
         ,
     };
     try sqliteCheck(sqlite.sqlite3_prepare_v2(db, sql, -1, &stmt, null), db);
@@ -1379,26 +1525,20 @@ fn queryHistorySubstringSearchEntry(
     try sqliteCheck(sqlite.sqlite3_bind_int(stmt, 5, @intFromBool(filters.successful)), db);
     try sqliteCheck(sqlite.sqlite3_bind_int(stmt, 6, @intFromBool(filters.session)), db);
     try sqliteCheck(sqlite.sqlite3_bind_text(stmt, 7, session_id.ptr, @intCast(session_id.len), null), db);
-    const rc = sqlite.sqlite3_step(stmt);
-    if (rc == sqlite.SQLITE_DONE) return null;
-    if (rc != sqlite.SQLITE_ROW) try sqliteCheck(rc, db);
-    const command_text = sqlite.sqlite3_column_text(stmt, 1) orelse return null;
-    return .{
-        .id = offset + 1,
-        .text = try allocator.dupe(u8, std.mem.span(command_text)),
-        .when = sqlite.sqlite3_column_int64(stmt, 2),
-    };
+    try sqliteCheck(sqlite.sqlite3_bind_int64(stmt, 8, @intCast(limit)), db);
+    return collectHistorySearchEntries(allocator, db, stmt.?, offset);
 }
 
-fn queryHistoryListEntry(
+fn queryHistoryListEntries(
     allocator: std.mem.Allocator,
     db: *sqlite.sqlite3,
     cwd: []const u8,
     session_id: []const u8,
     filters: line_editor.HistorySearchFilters,
     cursor: ?i64,
+    limit: usize,
     direction: HistoryDirection,
-) !?line_editor.HistoryView.HistoryEntry {
+) ![]line_editor.HistoryView.HistoryEntry {
     const offset = if (cursor) |value| @max(value, 0) else 0;
     const sql = switch (direction) {
         .previous =>
@@ -1416,7 +1556,7 @@ fn queryHistoryListEntry(
         \\      and newer.id > h.id
         \\  )
         \\order by (h.cwd = ?2) desc, h.id desc
-        \\limit 1 offset ?6
+        \\limit ?7 offset ?6
         ,
         .next =>
         \\select h.id, h.command, h.started_at
@@ -1433,7 +1573,7 @@ fn queryHistoryListEntry(
         \\      and newer.id > h.id
         \\  )
         \\order by (h.cwd = ?2) asc, h.id asc
-        \\limit 1 offset ?6
+        \\limit ?7 offset ?6
         ,
     };
     var stmt: ?*sqlite.sqlite3_stmt = null;
@@ -1445,15 +1585,34 @@ fn queryHistoryListEntry(
     try sqliteCheck(sqlite.sqlite3_bind_int(stmt, 4, @intFromBool(filters.session)), db);
     try sqliteCheck(sqlite.sqlite3_bind_text(stmt, 5, session_id.ptr, @intCast(session_id.len), null), db);
     try sqliteCheck(sqlite.sqlite3_bind_int64(stmt, 6, offset), db);
-    const rc = sqlite.sqlite3_step(stmt);
-    if (rc == sqlite.SQLITE_DONE) return null;
-    if (rc != sqlite.SQLITE_ROW) try sqliteCheck(rc, db);
-    const command_text = sqlite.sqlite3_column_text(stmt, 1) orelse return null;
-    return .{
-        .id = offset + 1,
-        .text = try allocator.dupe(u8, std.mem.span(command_text)),
-        .when = sqlite.sqlite3_column_int64(stmt, 2),
-    };
+    try sqliteCheck(sqlite.sqlite3_bind_int64(stmt, 7, @intCast(limit)), db);
+    return collectHistorySearchEntries(allocator, db, stmt.?, offset);
+}
+
+fn collectHistorySearchEntries(
+    allocator: std.mem.Allocator,
+    db: *sqlite.sqlite3,
+    stmt: *sqlite.sqlite3_stmt,
+    offset: i64,
+) ![]line_editor.HistoryView.HistoryEntry {
+    var entries: std.ArrayList(line_editor.HistoryView.HistoryEntry) = .empty;
+    errdefer {
+        for (entries.items) |entry| entry.deinit(allocator);
+        entries.deinit(allocator);
+    }
+    while (true) {
+        const rc = sqlite.sqlite3_step(stmt);
+        if (rc == sqlite.SQLITE_DONE) break;
+        if (rc != sqlite.SQLITE_ROW) try sqliteCheck(rc, db);
+        const command_text = sqlite.sqlite3_column_text(stmt, 1) orelse continue;
+        try entries.ensureUnusedCapacity(allocator, 1);
+        entries.appendAssumeCapacity(.{
+            .id = offset + @as(i64, @intCast(entries.items.len)) + 1,
+            .text = try allocator.dupe(u8, std.mem.span(command_text)),
+            .when = sqlite.sqlite3_column_int64(stmt, 2),
+        });
+    }
+    return entries.toOwnedSlice(allocator);
 }
 
 fn appendHistoryFtsQuery(allocator: std.mem.Allocator, output: *std.ArrayList(u8), query: []const u8) !void {
@@ -2063,7 +2222,64 @@ test "history search filters with fts and orders newest first" {
     try std.testing.expectEqualStrings("git status", second.text);
     try std.testing.expectEqual(@as(i64, 30), second.when);
 
+    const page = try history.searchPage(std.testing.allocator, "git sta", "", "", .{}, null, 20);
+    defer {
+        for (page) |entry| entry.deinit(std.testing.allocator);
+        std.testing.allocator.free(page);
+    }
+    try std.testing.expectEqual(@as(usize, 2), page.len);
+    try std.testing.expectEqualStrings("echo git status", page[0].text);
+    try std.testing.expectEqualStrings("git status", page[1].text);
+
     try std.testing.expect(try history.searchEntry(std.testing.allocator, "gco", "", "", .{}, null) == null);
+}
+
+test "history search returns whitespace-only results one page at a time" {
+    const path = "rush-history-whitespace-page-test.sqlite";
+    try deleteHistoryDbFilesIfExists(std.testing.io, path);
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path ++ "-wal") catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path ++ "-shm") catch {};
+
+    var history = try History.init(std.testing.allocator);
+    defer history.deinit();
+    try history.load(std.testing.io, path);
+    for (0..25) |index| {
+        var command_buffer: [32]u8 = undefined;
+        const command = try std.fmt.bufPrint(&command_buffer, "echo item {d}", .{index});
+        try insertHistoryRecord(history.db, .{ .cmd = command, .when = @intCast(index) });
+    }
+
+    const first_page = try history.searchPage(std.testing.allocator, "   ", "", "", .{}, null, 20);
+    defer {
+        for (first_page) |entry| entry.deinit(std.testing.allocator);
+        std.testing.allocator.free(first_page);
+    }
+    try std.testing.expectEqual(@as(usize, 20), first_page.len);
+    try std.testing.expectEqual(@as(i64, 1), first_page[0].id);
+    try std.testing.expectEqualStrings("echo item 24", first_page[0].text);
+    try std.testing.expectEqual(@as(i64, 20), first_page[19].id);
+    try std.testing.expectEqualStrings("echo item 5", first_page[19].text);
+
+    const second_page = try history.searchPage(std.testing.allocator, "   ", "", "", .{}, 20, 20);
+    defer {
+        for (second_page) |entry| entry.deinit(std.testing.allocator);
+        std.testing.allocator.free(second_page);
+    }
+    try std.testing.expectEqual(@as(usize, 5), second_page.len);
+    try std.testing.expectEqual(@as(i64, 21), second_page[0].id);
+    try std.testing.expectEqualStrings("echo item 4", second_page[0].text);
+    try std.testing.expectEqual(@as(i64, 25), second_page[4].id);
+    try std.testing.expectEqualStrings("echo item 0", second_page[4].text);
+
+    const forward_page = try history.searchNextPage(std.testing.allocator, "   ", "", "", .{}, null, 20);
+    defer {
+        for (forward_page) |entry| entry.deinit(std.testing.allocator);
+        std.testing.allocator.free(forward_page);
+    }
+    try std.testing.expectEqual(@as(usize, 20), forward_page.len);
+    try std.testing.expectEqualStrings("echo item 0", forward_page[0].text);
+    try std.testing.expectEqualStrings("echo item 19", forward_page[19].text);
 }
 
 test "history search matches punctuation queries as substrings" {


### PR DESCRIPTION
Rush's fallback code for when it can't leverage sqlite's full text search (e.g query contains only spaces) can get really slow.

### Problem

That fallback is relatively expensive because it ranks the current directory first and deduplicates commands. The editor previously assembled its 20-result page one row at a time, executing the full query again with successive offsets. Consequently, every Space could synchronously run the expensive query up to 20 times.

### Fix

This adds page-oriented history search callbacks. The SQLite provider now retrieves the complete 20-result page with one prepared and executed LIMIT 20 query instead of 20 LIMIT 1 queries.

Quick before/after with holding down my spacebar. My local db is ~6k entries for reference:

Before:

https://github.com/user-attachments/assets/8f6869be-e64e-4ffa-8956-61a6d40b9658


After:

https://github.com/user-attachments/assets/60840480-55a6-4be9-9dcf-936cdfd8d7c8



